### PR TITLE
support writeAt offset neq 0, fixes #16

### DIFF
--- a/nbdserver/Godeps/Godeps.json
+++ b/nbdserver/Godeps/Godeps.json
@@ -5,7 +5,7 @@
 	"Deps": [
 		{
 			"ImportPath": "github.com/g8os/gonbdserver/nbd",
-			"Rev": "8d60fd846f7b6a11cece85f034ce17b635273316"
+			"Rev": "608acee50fd3ac0fde4482345522198bcac2b3a5"
 		},
 		{
 			"ImportPath": "github.com/garyburd/redigo/internal",


### PR DESCRIPTION
Previously reading at a local offset `> 0` was possible only during the `ReadAt operation`, not in the `WriteAt` operation. In the `WriteAt` operation it would simply throw an error. This was an issue as the following use-case would fail because of it:

```
$ curl -O https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
$ qemu-img convert -n ubuntu-16.04-server-cloudimg-amd64-disk1.img \
    -O nbd nbd+tcp://192.168.1.41:6666/ubuntu1604

/build/qemu-b8pg78/qemu-2.5+dfsg/nbd.c:nbd_receive_reply():L898: read failed
qemu-img: error while writing sector 0: Input/output error

# on the server side you would see the following error:
# ...
... [WARN] Client 192.168.64.21:39688/ubuntu1604 got write I/O error: \
    Stupid client does not write on block boundary, offset: 51712 length: 4096
# ...
```

This PR makes it possible to write at non-boundary offsets, also known as local non-zero offsets.
A build, using this PR, has also been tested on the use-case given above, and it has been confirmed that using this PR that use-case is now possible.

> ⚠ Note that even though the content seems to be written correctly, I'm not sure how to test the converted image, now available on the NBD. Feel free to let me know what the next steps would be to test and confirm this 100%. Or feel free to test it yourself and let me know the results.

Because of this PR, a call to `WriteAt` can now result in 4 different scenarios:

+ There is a local non-zero offset, and the content length combined with that offset, goes beyond the blocksize, meaning we have to spread it over 2 different blocks:
    1. first we'll make a call to `WriteAt` again, to write the first block, merging any existing content, and store the new LBA;
   2. if that succeeds we set the new second block, merging any original content, and storing the new hash in the LBA as well. Thus we have now stored 2 content hashes in total;
+ There is a local non-zero offset, but the given content still fits in one block. We simply merge existing content with the new given content and store the new hash in the LBA;
+ The local offset is 0, but the given content length is smaller than a block size. We merge existing content, with the newly given content, and store the new hash in the LBA;
+ The local offset is 0, and the given content length is exactly a block size. This is our ideal situation, and hopefully the norm. We check if the hash is already stored, in which case we simply return, otherwise we do write the content and store the hash in the LBA. As you might notice, this scenario, was the only scenario possible in the original nbd code;

If I'm correct in my assumptions, 🤞, this PR fixes issue #16.
