### PR TITLE
add content ref. and gc to dedupedStorage

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -34,7 +34,7 @@
 		},
 		{
 			"ImportPath": "github.com/g8os/gonbdserver/nbd",
-			"Rev": "585d2378301579044ed1d2bac176b5ba431d56f3"
+			"Rev": "b6a81a628665689535d04401b61a5773dc0fd836"
 		},
 		{
 			"ImportPath": "github.com/garyburd/redigo/internal",
@@ -118,48 +118,48 @@
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/config",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/ledis",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/rpl",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/server",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/store",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/store/driver",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/store/goleveldb",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/store/leveldb",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/ledisdb/store/rocksdb",
-			"Comment": "v0.5-79-g80ea7b8",
-			"Rev": "80ea7b8bca787181baa810e8e032cf7e10206143"
+			"Comment": "v0.5-80-g5835ab9",
+			"Rev": "5835ab9b2b80e1e3f7dd31b7526836c4a0cbf8b2"
 		},
 		{
 			"ImportPath": "github.com/siddontang/rdb",

--- a/nbdserver/ardb/backend.go
+++ b/nbdserver/ardb/backend.go
@@ -152,6 +152,7 @@ func (ab *Backend) Flush(ctx context.Context) (err error) {
 //Close implements nbd.Backend.Close
 func (ab *Backend) Close(ctx context.Context) (err error) {
 	ab.storageClusterClient.Close()
+	err = ab.storage.Close()
 	return
 }
 
@@ -175,4 +176,10 @@ func (ab *Backend) HasFua(ctx context.Context) bool {
 // Yes, we support flush
 func (ab *Backend) HasFlush(ctx context.Context) bool {
 	return true
+}
+
+// GoBackground implements Backend.GoBackground
+// and the actual work is delegated to the underlying storage
+func (ab *Backend) GoBackground(ctx context.Context) {
+	ab.storage.GoBackground(ctx)
 }

--- a/nbdserver/ardb/deduped.go
+++ b/nbdserver/ardb/deduped.go
@@ -1,7 +1,9 @@
 package ardb
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
 	"github.com/garyburd/redigo/redis"
 	log "github.com/glendc/go-mini-log"
@@ -11,13 +13,20 @@ import (
 
 // newDedupedStorage returns the deduped backendStorage implementation
 func newDedupedStorage(vdiskID string, blockSize int64, provider redisConnectionProvider, vlba *lba.LBA) backendStorage {
-	return &dedupedStorage{
+	storage := &dedupedStorage{
 		blockSize:       blockSize,
 		vdiskID:         vdiskID,
 		zeroContentHash: lba.HashBytes(make([]byte, blockSize)),
 		provider:        provider,
 		lba:             vlba,
+		cancelChan:      make(chan struct{}, 1),
 	}
+
+	for i := 0; i < dedupBackgroundWorkerCount; i++ {
+		storage.rcActionChannels[i] = make(chan rcAction, dedupBackgroundWorkerBufferSize)
+	}
+
+	return storage
 }
 
 // dedupedStorage is a backendStorage implementation,
@@ -29,6 +38,10 @@ type dedupedStorage struct {
 	zeroContentHash lba.Hash
 	provider        redisConnectionProvider
 	lba             *lba.LBA
+
+	// used for background thread
+	cancelChan       chan struct{}
+	rcActionChannels [dedupBackgroundWorkerCount]chan rcAction
 }
 
 // Set implements backendStorage.Set
@@ -39,33 +52,17 @@ func (ds *dedupedStorage) Set(blockIndex int64, content []byte) (err error) {
 		return
 	}
 
-	//Execute in a function so the redis connection is released before storing the hash in the LBA
-	// If the metadataserver is the same as the content, this causes a deadlock if the connection is not released yet
-	// and now it can already be reused faster as well
-	err = func() (err error) {
-		conn, err := ds.getRedisConnection(hash)
-		if err != nil {
-			return
-		}
-		defer conn.Close()
+	// Get Previous Hash
+	prevHash, _ := ds.lba.Get(blockIndex)
 
-		exists, err := redis.Bool(conn.Do("EXISTS", hash))
-		if err != nil || exists {
-			return
-		}
-
-		// write content to redis in case it doesn't exist yet
-		_, err = conn.Do("SET", hash, content)
-		return
-	}()
+	// reference the content to this vdisk,
+	// and set the content itself, if it didn't exist yet
+	err = ds.setContent(prevHash, hash, content)
 	if err != nil {
 		return
 	}
 
-	// Write Hash to LBA
-
-	err = ds.lba.Set(blockIndex, hash)
-	return
+	return ds.lba.Set(blockIndex, hash)
 }
 
 // Merge implements backendStorage.Merge
@@ -93,7 +90,9 @@ func (ds *dedupedStorage) Merge(blockIndex, offset int64, content []byte) (err e
 	copy(mergedContent[offset:], content)
 
 	// store new content
-	return ds.Set(blockIndex, mergedContent)
+	// (dereferencing of previousHash happens in ds.Set logic)
+	err = ds.Set(blockIndex, mergedContent)
+	return
 }
 
 // Get implements backendStorage.Get
@@ -107,7 +106,24 @@ func (ds *dedupedStorage) Get(blockIndex int64) (content []byte, err error) {
 
 // Delete implements backendStorage.Delete
 func (ds *dedupedStorage) Delete(blockIndex int64) (err error) {
+	// first get hash
+	hash, _ := ds.lba.Get(blockIndex)
+	if hash == nil {
+		// content didn't exist yet,
+		// so we've nothing to do here
+		return
+	}
+
+	// delete the actual hash from the LBA first
 	err = ds.lba.Delete(blockIndex)
+	if err != nil {
+		return
+	}
+
+	// only if the hash was succesfully deleted from the vdisk's LBA,
+	// we should dereference the content,
+	// and delete the content if the new reference count < 1
+	ds.dereferenceContent(hash)
 	return
 }
 
@@ -115,6 +131,66 @@ func (ds *dedupedStorage) Delete(blockIndex int64) (err error) {
 func (ds *dedupedStorage) Flush() (err error) {
 	err = ds.lba.Flush()
 	return
+}
+
+// Close implements backendStorage.Close
+func (ds *dedupedStorage) Close() error {
+	ds.cancelChan <- struct{}{}
+	return nil
+}
+
+// GoBackground implements backendStorage.GoBackground
+func (ds *dedupedStorage) GoBackground(ctx context.Context) {
+	var wg sync.WaitGroup
+
+	for i := range ds.rcActionChannels {
+		wg.Add(1)
+		workerID := i
+		go func() {
+			defer wg.Done()
+			ds.goBackgroundWorker(ctx, workerID)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func (ds *dedupedStorage) goBackgroundWorker(ctx context.Context, workerID int) {
+	log.Debugf("starting deduped background worker #%d", workerID+1)
+	ch := ds.rcActionChannels[workerID]
+	for {
+		select {
+		case action := <-ch:
+			var err error
+
+			switch action.Type {
+			case rcIncrease:
+				err = ds.goReferenceContent(action.Hash)
+			case rcDecrease:
+				err = ds.goDereferenceContent(action.Hash)
+			default:
+				err = fmt.Errorf(
+					"background rc action %d for %v not recognized",
+					action.Type, action.Hash)
+			}
+
+			if err != nil {
+				log.Infof(
+					"worker #%d: error during content (de)referencing: %s",
+					workerID+1, err.Error())
+			}
+
+		case <-ds.cancelChan:
+			log.Debugf("close dedupedStorage %q's background worker #%d",
+				ds.vdiskID, workerID+1)
+			return
+
+		case <-ctx.Done():
+			log.Debugf("forcefully exit dedupedStorage %q's background worker #%d",
+				ds.vdiskID, workerID+1)
+			return
+		}
+	}
 }
 
 func (ds *dedupedStorage) getRedisConnection(hash lba.Hash) (redis.Conn, error) {
@@ -138,7 +214,7 @@ func (ds *dedupedStorage) getContent(hash lba.Hash) (content []byte, err error) 
 		}
 		defer conn.Close()
 
-		content, err = redisBytes(conn.Do("GET", hash))
+		content, err = redisBytes(conn.Do("GET", hash.Bytes()))
 		return
 	}()
 	if err != nil || content != nil {
@@ -156,7 +232,7 @@ func (ds *dedupedStorage) getContent(hash lba.Hash) (content []byte, err error) 
 		}
 		defer conn.Close()
 
-		content, err = redis.Bytes(conn.Do("GET", hash))
+		content, err = redisBytes(conn.Do("GET", hash.Bytes()))
 		if err != nil {
 			log.Debugf(
 				"content for %v not available in local-, nor in remote storage: %s",
@@ -177,7 +253,7 @@ func (ds *dedupedStorage) getContent(hash lba.Hash) (content []byte, err error) 
 				return
 			}
 
-			_, err = conn.Do("SET", hash, content)
+			err = redisSendNow(conn, "SET", hash.Bytes(), content)
 			if err != nil {
 				// we won't return error however, but just log it
 				log.Infof("couldn't store remote content in local storage: %s", err.Error())
@@ -192,3 +268,120 @@ func (ds *dedupedStorage) getContent(hash lba.Hash) (content []byte, err error) 
 	// err = nil, content = ?
 	return
 }
+
+// setContent if it doesn't exist yet,
+// and increase the reference counter, by adding this vdiskID
+func (ds *dedupedStorage) setContent(prevHash, curHash lba.Hash, content []byte) (err error) {
+	err = func() (err error) {
+		conn, err := ds.getRedisConnection(curHash)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		exists, err := redis.Bool(conn.Do("EXISTS", curHash.Bytes()))
+		if err == nil && !exists {
+			err = redisSendNow(conn, "SET", curHash.Bytes(), content)
+		}
+
+		return
+	}()
+	if err != nil {
+		return
+	}
+
+	// reference currentHash
+	ds.referenceContent(curHash)
+	if prevHash != nil {
+		// dereference previousHash
+		ds.dereferenceContent(prevHash)
+	}
+
+	return nil
+}
+
+// sender of the reference content action
+func (ds *dedupedStorage) referenceContent(hash lba.Hash) {
+	workerID := dsWorkerID(hash)
+	ds.rcActionChannels[workerID] <- rcAction{
+		Type: rcIncrease,
+		Hash: hash,
+	}
+}
+
+// receiver of the reference content action
+func (ds *dedupedStorage) goReferenceContent(hash lba.Hash) (err error) {
+	key := dsReferenceKey(hash)
+
+	conn, err := ds.getRedisConnection(hash)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	err = redisSendNow(conn, "INCR", key)
+	return
+}
+
+// sender of the dereference content action
+func (ds *dedupedStorage) dereferenceContent(hash lba.Hash) {
+	workerID := dsWorkerID(hash)
+	ds.rcActionChannels[workerID] <- rcAction{
+		Type: rcDecrease,
+		Hash: hash,
+	}
+}
+
+// receiver of the dereference content action
+func (ds *dedupedStorage) goDereferenceContent(hash lba.Hash) (err error) {
+	key := dsReferenceKey(hash)
+
+	conn, err := ds.getRedisConnection(hash)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	count, err := redis.Int64(conn.Do("DECR", key))
+	if err != nil || count > 0 {
+		return
+	}
+
+	err = redisSendNow(conn, "DEL", hash.Bytes(), key)
+	return
+}
+
+func dsWorkerID(hash lba.Hash) int {
+	return int(hash[0]) % dedupBackgroundWorkerCount
+}
+
+func dsReferenceKey(hash lba.Hash) (key []byte) {
+	key = make([]byte, rcKeyPrefixLength+lba.HashSize)
+	copy(key, rcKeyPrefix[:])
+	copy(key[rcKeyPrefixLength:], hash[:])
+	return
+}
+
+const (
+	rcKeyPrefix       = "rc:"
+	rcKeyPrefixLength = len(rcKeyPrefix)
+)
+
+const (
+	dedupBackgroundWorkerCount      = 8
+	dedupBackgroundWorkerBufferSize = 32
+)
+
+type rcAction struct {
+	// Type of action
+	Type rcActionType
+	// Hash the actions applies on
+	Hash lba.Hash
+}
+
+type rcActionType int
+
+const (
+	rcIncrease rcActionType = iota
+	rcDecrease
+)

--- a/nbdserver/docs/backendStorage.md
+++ b/nbdserver/docs/backendStorage.md
@@ -22,6 +22,8 @@ This storage is called deduped, because no duplicated content is stored. [Hash][
 
 It is possible (and in fact desired), that multiple block indices of the (same or different) [vdisk][vdisk] point to the same [hash][blake2b.hash] and thus content.
 
+Each time a block is referenced by an index in a [vdisk][vdisk]'s LBA, the reference counter for that content is increased. When a block in a [vdisk][vdisk]'s LBA is "deleted", the actual content isn't deleted and instead simply dereferenced. When a block is dereferenced the reference counter for that content is decreased. When the reference counter for a block reaches 0, the content itself is permanently deleted from the (local) storage.
+
 See [the deduped code](../ardb/deduped.go) for more information.
 
 ## Nondeduped Storage

--- a/nbdserver/lba/hash.go
+++ b/nbdserver/lba/hash.go
@@ -19,10 +19,6 @@ var (
 //Hash is just a bytearray of size HashSize
 type Hash []byte
 
-// nilHash used internally in LBA as place holder for
-// a non-existing hash
-var nilHash = NewHash()
-
 // HashBytes takes a byte slice .
 func HashBytes(data []byte) Hash {
 	b := blake2b.Sum256(data)
@@ -38,4 +34,9 @@ func NewHash() (hash Hash) {
 //Equals returns true if two hashes are the same
 func (h Hash) Equals(compareTo Hash) bool {
 	return bytes.Equal(h, compareTo)
+}
+
+//Bytes returns the hash as a slice of bytes
+func (h Hash) Bytes() []byte {
+	return h[:]
 }

--- a/nbdserver/lba/hash_test.go
+++ b/nbdserver/lba/hash_test.go
@@ -12,11 +12,11 @@ func TestHashBytes(t *testing.T) {
 	rand.Read(data)
 	h := HashBytes(data)
 	if assert.NotNil(t, h, "Nil hash returned from the hashfunction") {
-		assert.False(t, h.Equals(nilHash), "empty has returned")
+		assert.False(t, h.Equals(NilHash), "empty has returned")
 	}
 }
 
 func TestNilHash(t *testing.T) {
-	assert.Len(t, nilHash, HashSize)
-	assert.True(t, NewHash().Equals(nilHash))
+	assert.Len(t, NilHash, HashSize)
+	assert.True(t, NewHash().Equals(NilHash))
 }

--- a/nbdserver/lba/lba.go
+++ b/nbdserver/lba/lba.go
@@ -115,6 +115,9 @@ func (lba *LBA) Get(blockIndex int64) (h Hash, err error) {
 	// get the hash
 	hashIndex := blockIndex % NumberOfRecordsPerLBAShard
 	h = shard.Get(hashIndex)
+	if h.Equals(NilHash) {
+		h = nil
+	}
 
 	return
 }

--- a/nbdserver/lba/shard.go
+++ b/nbdserver/lba/shard.go
@@ -23,14 +23,16 @@ func newShard() *shard {
 	return shard
 }
 
-func shardFromBytes(bytes []byte) (shard *shard, err error) {
-	if len(bytes) < BytesPerShard {
-		err = fmt.Errorf("raw shard is too small, expected %d bytes", BytesPerShard)
+func shardFromBytes(bytes []byte) (s *shard, err error) {
+	if length := len(bytes); length != BytesPerShard {
+		err = fmt.Errorf(
+			"raw shard contains %d bytes, while expected %d bytes",
+			length, BytesPerShard)
 		return
 	}
 
-	shard = newShard()
-	shard.hashes = bytes
+	s = new(shard)
+	s.hashes = bytes
 	return
 }
 
@@ -49,17 +51,21 @@ func (s *shard) UnsetDirty() {
 
 func (s *shard) Set(hashIndex int64, hash Hash) {
 	offset := hashIndex * HashSize
+
 	if hash == nil {
-		hash = nilHash
+		hash = NilHash
 	}
 
 	copy(s.hashes[offset:offset+HashSize], hash)
 	s.dirty = true
+	return
 }
 
-func (s *shard) Get(hashIndex int64) Hash {
+func (s *shard) Get(hashIndex int64) (hash Hash) {
+	hash = NewHash()
 	offset := hashIndex * HashSize
-	return Hash(s.hashes[offset : offset+HashSize])
+	copy(hash[:], s.hashes[offset:])
+	return
 }
 
 func (s *shard) IsNil() bool {

--- a/nbdserver/lba/shard_test.go
+++ b/nbdserver/lba/shard_test.go
@@ -30,15 +30,16 @@ func TestCreateShard(t *testing.T) {
 		// getting a shard will keep it clean
 		for i := int64(0); i < NumberOfRecordsPerLBAShard; i++ {
 			h := shard.Get(i) // NOTE: there is no out-of-range protection
-			assert.Equal(t, nilHash, h, "created from bytes, contain all nil hashes")
+			assert.Equal(t, NilHash, h, "created from bytes, contain all nil hashes")
 		}
 
 		// setting a shard will make it dirty though
 		shard.Set(0, HashBytes(nil))
+
 		assert.True(t, shard.Dirty(), "modified shard should be dirty")
 		h := shard.Get(0) // NOTE: there is no out-of-range protection
 		if assert.NotEmpty(t, h, "created from bytes, no hash should be nil") {
-			assert.NotEqual(t, nilHash, h, "should be not equal to the nilhash")
+			assert.NotEqual(t, NilHash, h, "should be not equal to the NilHash")
 		}
 
 		// a shard can be marked non-dirty by the user,
@@ -63,14 +64,14 @@ func TestCreateShard(t *testing.T) {
 
 				// first shard should still not be equal
 				f := shard.Get(0) // NOTE: there is no out-of-range protection
-				if assert.NotEmpty(t, f, "created from bytes, no hash should be nil") {
-					assert.Equal(t, h, f, "should be not equal to the hash written earlier")
+				if assert.NotNil(t, f, "created from bytes, but with noting in, so it's all nil") {
+					assert.Equal(t, h, f, "should be equal to the hash written earlier")
 				}
 
 				// getting a shard will keep it clean
 				for i := int64(1); i < NumberOfRecordsPerLBAShard; i++ {
 					h := shard.Get(i) // NOTE: there is no out-of-range protection
-					assert.Equal(t, nilHash, h, "created from bytes, contain all nil hashes")
+					assert.Equal(t, NilHash, h, "created from bytes, contain all nil hashes")
 				}
 			}
 		}

--- a/storagecluster/cluster.go
+++ b/storagecluster/cluster.go
@@ -266,7 +266,7 @@ func (cc *ClusterClient) loadConfig() bool {
 			cc.storageClusterName)
 		storageClusterName = cc.storageClusterName
 	} else {
-		cc.logger.Info("couldn't load config: either the volumeID or the storageClusterName has to be defined")
+		cc.logger.Info("couldn't load config: either the vdiskID or the storageClusterName has to be defined")
 		return false
 	}
 

--- a/vendor/github.com/g8os/gonbdserver/nbd/file.go
+++ b/vendor/github.com/g8os/gonbdserver/nbd/file.go
@@ -82,6 +82,11 @@ func (fb *FileBackend) HasFlush(ctx context.Context) bool {
 	return true
 }
 
+// GoBackground implements Backend.GoBackground
+func (fb *FileBackend) GoBackground(ctx context.Context) {
+	// No background thread needed
+}
+
 // NewFileBackend generates a new file backend
 func NewFileBackend(ctx context.Context, ec *ExportConfig) (Backend, error) {
 	perms := os.O_RDWR

--- a/vendor/github.com/siddontang/ledisdb/server/client_resp.go
+++ b/vendor/github.com/siddontang/ledisdb/server/client_resp.go
@@ -228,7 +228,6 @@ func newWriterRESP(conn net.Conn, size int) *respWriter {
 func (w *respWriter) writeError(err error) {
 	w.buff.Write(hack.Slice("-"))
 	if err != nil {
-		w.buff.WriteByte(' ')
 		w.buff.Write(hack.Slice(err.Error()))
 	}
 	w.buff.Write(Delims)

--- a/vendor/github.com/siddontang/ledisdb/server/cmd_script.go
+++ b/vendor/github.com/siddontang/ledisdb/server/cmd_script.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	"github.com/siddontang/go/hack"
@@ -70,7 +71,7 @@ func evalGenericCommand(c *client, evalSha1 bool) (err error) {
 
 	if global.Type() == lua.LTNil {
 		if evalSha1 {
-			return fmt.Errorf("missing %s script", key)
+			return errors.New("NOSCRIPT no matching script, please use EVAL")
 		}
 
 		val, err := l.LoadString(hack.String(c.args[0]))


### PR DESCRIPTION
this PR fixes #42 

**TODO**:

- [x] add support for SET operations in the Redis STUB;
- [x] ensure that referencing is updated at all times (and add unit-tests to guarantee this):
   - [x] SetContent: reference new content, dereference previous content if it existed;
   - [x] DelContent: dereference content;
   - [x] MergeContent: reference new merged content, dereference previous content if it existed;
- [x] ensure that a single volume can reference content multiple times (using a `hashMap` and `HINCRBY` might be better at this point);
- [x] benchmark & investigate impact this PR has on the performance;
- [x] adapt design and implementation where needed;

**NOTE**: Not sure what to do with the copy volume lua script. As any volumes creates with that script, are not added to the reference sets for now, and thus these volumes might reference non-existing content, at some point.