### PR TITLE
allow predefined storageclustername

### DIFF
--- a/cmd/copyvolume/copy_same.go
+++ b/cmd/copyvolume/copy_same.go
@@ -11,8 +11,13 @@ func copySameConnection(logger log.Logger, input *userInput, conn redis.Conn) (e
 	logger.Infof("dumping volume %q and restoring it as volume %q",
 		input.Source.Volume, input.Target.Volume)
 
-	_, err = copySameScript.Do(conn,
-		input.Source.Volume, input.Target.Volume)
+	indexCount, err := redis.Int64(copySameScript.Do(conn,
+		input.Source.Volume, input.Target.Volume))
+	if err == nil {
+		logger.Infof("copied %d meta indices to volume %q",
+			indexCount, input.Target.Volume)
+	}
+
 	return
 }
 
@@ -41,5 +46,6 @@ if redis.call("EXISTS", destination) == 1 then
 end
 
 redis.call("RESTORE", destination, 0, redis.call("DUMP", source))
-return "OK"
+
+return redis.call("HLEN", destination)
 `

--- a/cmd/copyvolume/grid.go
+++ b/cmd/copyvolume/grid.go
@@ -7,7 +7,8 @@ import (
 )
 
 func getConnectionsFromGrid(logger log.Logger, input *userInput) (connA, connB redis.Conn, err error) {
-	cfgA, err := storagecluster.NewClusterConfig(input.Source.URL, input.Source.Volume, logger)
+	cfgA, err := storagecluster.NewClusterConfig(
+		input.Source.URL, input.Source.Volume, flagSourceStorageCluster, logger)
 	if err != nil {
 		return
 	}
@@ -20,7 +21,8 @@ func getConnectionsFromGrid(logger log.Logger, input *userInput) (connA, connB r
 		return
 	}
 
-	cfgB, err := storagecluster.NewClusterConfig(input.Target.URL, input.Target.Volume, logger)
+	cfgB, err := storagecluster.NewClusterConfig(
+		input.Target.URL, input.Target.Volume, flagTargetStorageCluster, logger)
 	if err != nil {
 		return
 	}

--- a/cmd/copyvolume/main.go
+++ b/cmd/copyvolume/main.go
@@ -26,7 +26,7 @@ func main() {
 	var logger log.Logger
 	if flagVerbose {
 		// log info to stderr
-		logger = log.New(os.Stderr, "", log.LstdFlags)
+		logger = log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
 	} else {
 		// discard all logs
 		logger = log.New(ioutil.Discard, "", 0)
@@ -72,6 +72,10 @@ func init() {
 	// register flags
 	flag.Var(&flagURLType, "t", "type of the given url(s); the gridapi url's or the direct metadataserver connectionstrings")
 	flag.BoolVar(&flagVerbose, "v", false, "log to stderr")
+	flag.StringVar(&flagSourceStorageCluster, "sourcesc", "",
+		"combined with api type it allows you to predefine the source's storageCluster name")
+	flag.StringVar(&flagTargetStorageCluster, "targetsc", "",
+		"combined with api type it allows you to predefine the target's storageCluster name")
 
 	// custom usage function
 	flag.Usage = printUsage
@@ -136,8 +140,10 @@ type userInput struct {
 
 // optional flags
 var (
-	flagURLType = urlType(urlTypeGrid)
-	flagVerbose bool
+	flagURLType              = urlType(urlTypeGrid)
+	flagVerbose              bool
+	flagTargetStorageCluster string
+	flagSourceStorageCluster string
 )
 
 // usage string
@@ -147,9 +153,9 @@ const (
 copy the metadata of a deduped volume
 
 usage:
-  %[1]s [-v] [-t %[2]s|%[3]s] source_volume target_volume source_url [target_url]
+  %[1]s [-v] [-t %[2]s|%[3]s] [-sourcesc name] [-targetsc name] source_volume target_volume source_url [target_url]
 
-  When no target_url is given, the target metadataserver is the same as the source metadataserver.
+  When no target_url is given, the target_url is the same as the source_url.
 `
 )
 

--- a/cmd/copyvolume/readme.md
+++ b/cmd/copyvolume/readme.md
@@ -25,4 +25,6 @@ usage:
   When no target_url is given, the target metadataserver is the same as the source metadataserver.
 
 + `[-v]`: log all (progress) info to STDERR;
-+ `[-t api|direct]`: define the type of the given url(s); the gridapi url's or the direct metadataserver connectionstrings.
++ `[-t api|direct]`: define the type of the given url(s), the gridapi url's or the direct metadataserver connectionstrings;
++ `[-sourcesc name]`: combined with api type it allows you to predefine the source's storageCluster name;
++ `[-targetsc name]`: combined with api type it allows you to predefine the target's storageCluster name;


### PR DESCRIPTION
meaning that when interacting with the storageClusterConfig,
one could choose to give the storageClusterName directly,
rather than relying on the volumeID to fetch the volumeInfo
and get the storageCluster from the fetched volumeInfo

also replacing flush with (watched) multi/exec for copy_different,
as we do want to ensure that /all/ indices get copied, not just some

fixes #59