### PR TITLE
Tlog : dynamic block length

### DIFF
--- a/tlog/tlogclient/capnp.go
+++ b/tlog/tlogclient/capnp.go
@@ -33,12 +33,14 @@ func buildCapnp(volID string, seq uint64, crc uint32,
 		return nil, fmt.Errorf("create block:%v", err)
 	}
 
+	// We don't need it anymore, left it undeleted
+	// because it is needed by the C++ version.
 	// we pad the volume ID to get fixed length volume ID
-	if len(volID) < volIDLen {
+	/*if len(volID) < volIDLen {
 		pad := make([]byte, volIDLen-len(volID))
 		b := append([]byte(volID), pad...)
 		volID = string(b)
-	}
+	}*/
 
 	block.SetVolumeId(volID)
 	block.SetSequence(seq)

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -176,7 +176,7 @@ func (c *Client) Send(volID string, seq uint64,
 		return err
 	}
 
-	prefix = uint32(len(b))
+	prefix = uint32(len(b) / 8)
 	if err := binary.Write(buf, binary.LittleEndian, prefix); err != nil {
 		return err
 	}

--- a/tlog/tlogclient/examples/get_last_data/main.go
+++ b/tlog/tlogclient/examples/get_last_data/main.go
@@ -43,7 +43,7 @@ func main() {
 	flag.StringVar(&conf.firstObjStorAddr, "first-objstor-addr", "127.0.0.1", "first objstor addr")
 	flag.IntVar(&conf.firstObjStorPort, "first-objstor-port", 16379, "first objstor port")
 	flag.StringVar(&conf.privKey, "priv-key", "12345678901234567890123456789012", "priv key")
-	flag.StringVar(&conf.volID, "vol-id", "12345678901234567890123456789012", "vol id")
+	flag.StringVar(&conf.volID, "vol-id", "1234567890", "vol id")
 	flag.BoolVar(&dumpContent, "dump-content", false, "dump content")
 
 	flag.Parse()

--- a/tlog/tlogclient/examples/send_tlog/.gitignore
+++ b/tlog/tlogclient/examples/send_tlog/.gitignore
@@ -1,0 +1,1 @@
+send_tlog

--- a/tlog/tlogclient/examples/send_tlog/client.go
+++ b/tlog/tlogclient/examples/send_tlog/client.go
@@ -20,7 +20,7 @@ func main() {
 
 	flag.Parse()
 
-	volID := "12345678901234567890123456789012"
+	volID := "1234567890"
 
 	clients := make([]*client.Client, numClient)
 	clientReady := make(chan int, numClient)

--- a/tlog/tlogserver/main.go
+++ b/tlog/tlogserver/main.go
@@ -14,7 +14,6 @@ type config struct {
 	privKey          string
 	firstObjStorPort int
 	firstObjStorAddr string
-	bufSize          int
 }
 
 func main() {
@@ -30,7 +29,6 @@ func main() {
 	flag.StringVar(&conf.firstObjStorAddr, "first-objstor-addr", "127.0.0.1", "first objstor addr")
 	flag.IntVar(&conf.firstObjStorPort, "first-objstor-port", 16379, "first objstor port")
 	flag.StringVar(&conf.privKey, "priv-key", "12345678901234567890123456789012", "private key")
-	flag.IntVar(&conf.bufSize, "buf-size", 16488, "buffer")
 
 	flag.Parse()
 

--- a/tlog/tlogserver/server.go
+++ b/tlog/tlogserver/server.go
@@ -88,6 +88,7 @@ func (s *Server) handle(conn net.Conn) error {
 }
 func (s *Server) readData(conn net.Conn) ([]byte, error) {
 	// read length prefix
+	// as described in https://capnproto.org/encoding.html#serialization-over-a-stream
 	var segmentNum, length uint32
 
 	if err := binary.Read(conn, binary.LittleEndian, &segmentNum); err != nil {
@@ -98,7 +99,7 @@ func (s *Server) readData(conn net.Conn) ([]byte, error) {
 		return nil, err
 	}
 
-	data := make([]byte, length)
+	data := make([]byte, length*8)
 	_, err := io.ReadFull(conn, data)
 	return data, err
 }

--- a/tlog/tlogserver/server.go
+++ b/tlog/tlogserver/server.go
@@ -5,6 +5,7 @@ package main
 import "C"
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -25,9 +26,8 @@ type Server struct {
 
 func NewServer(port int, conf *config) (*Server, error) {
 	return &Server{
-		port:    port,
-		bufSize: conf.bufSize,
-		f:       newFlusher(conf),
+		port: port,
+		f:    newFlusher(conf),
 	}, nil
 }
 
@@ -49,14 +49,14 @@ func (s *Server) Listen() {
 }
 
 func (s *Server) handle(conn net.Conn) error {
+
 	defer conn.Close()
 	for {
-		// read
-		data := make([]byte, s.bufSize)
-		_, err := io.ReadFull(conn, data)
+		data, err := s.readData(conn)
 		if err != nil {
 			return err
 		}
+
 		buf := bytes.NewBuffer(data)
 
 		// decode
@@ -85,6 +85,22 @@ func (s *Server) handle(conn net.Conn) error {
 			return err
 		}
 	}
+}
+func (s *Server) readData(conn net.Conn) ([]byte, error) {
+	// read length prefix
+	var segmentNum, length uint32
+
+	if err := binary.Read(conn, binary.LittleEndian, &segmentNum); err != nil {
+		return nil, err
+	}
+
+	if err := binary.Read(conn, binary.LittleEndian, &length); err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, length)
+	_, err := io.ReadFull(conn, data)
+	return data, err
 }
 
 // decode tlog message from client


### PR DESCRIPTION
Closes #74.

By adding capnp prefix before each block message as
 described in https://capnproto.org/encoding.html#serialization-over-a-stream.