### PR TITLE
fix unit tests reliability and broken deduped redis logic

### DIFF
--- a/nbdserver/ardb/ardb_test.go
+++ b/nbdserver/ardb/ardb_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/g8os/blockstor/redisstub"
 	"github.com/garyburd/redigo/redis"
@@ -69,8 +68,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 			t.Fatal(err)
 		}
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
 
 	// getting this content should now be possible
 	content, err = storage.Get(testBlockIndexA)
@@ -86,8 +83,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
 	// getting the content should now fail
 	content, err = storage.Get(testBlockIndexB)
 	if err != nil {
@@ -102,8 +97,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
 	// getting the content should be fine
 	content, err = storage.Get(testBlockIndexB)
 	if err != nil {
@@ -118,8 +111,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
 	// getting the content should be fine
 	content, err = storage.Get(testBlockIndexB)
 	if err != nil {
@@ -134,8 +125,7 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
+
 	// content should now be nil
 	content, err = storage.Get(testBlockIndexA)
 	if err != nil {
@@ -148,8 +138,7 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
+
 	// content should be merged
 	content, err = storage.Get(testBlockIndexA)
 	if err != nil {
@@ -164,8 +153,7 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give any async processes time to process
-	time.Sleep(time.Millisecond * 200)
+
 	// content should now be nil
 	content, err = storage.Get(testBlockIndexB)
 	if err != nil {

--- a/nbdserver/ardb/deduped.go
+++ b/nbdserver/ardb/deduped.go
@@ -253,7 +253,7 @@ func (ds *dedupedStorage) getContent(hash lba.Hash) (content []byte, err error) 
 				return
 			}
 
-			err = redisSendNow(conn, "SET", hash.Bytes(), content)
+			_, err = conn.Do("SET", hash.Bytes(), content)
 			if err != nil {
 				// we won't return error however, but just log it
 				log.Infof("couldn't store remote content in local storage: %s", err.Error())
@@ -281,7 +281,7 @@ func (ds *dedupedStorage) setContent(prevHash, curHash lba.Hash, content []byte)
 
 		exists, err := redis.Bool(conn.Do("EXISTS", curHash.Bytes()))
 		if err == nil && !exists {
-			err = redisSendNow(conn, "SET", curHash.Bytes(), content)
+			_, err = conn.Do("SET", curHash.Bytes(), content)
 		}
 
 		return
@@ -319,7 +319,7 @@ func (ds *dedupedStorage) goReferenceContent(hash lba.Hash) (err error) {
 	}
 	defer conn.Close()
 
-	err = redisSendNow(conn, "INCR", key)
+	_, err = conn.Do("INCR", key)
 	return
 }
 
@@ -347,7 +347,7 @@ func (ds *dedupedStorage) goDereferenceContent(hash lba.Hash) (err error) {
 		return
 	}
 
-	err = redisSendNow(conn, "DEL", hash.Bytes(), key)
+	_, err = conn.Do("DEL", hash.Bytes(), key)
 	return
 }
 

--- a/nbdserver/ardb/deduped_test.go
+++ b/nbdserver/ardb/deduped_test.go
@@ -71,7 +71,6 @@ func createTestDedupedStorage(t *testing.T, vdiskID string, blockSize, blockCoun
 // testDedupContentExists tests if
 // the given content exists in the database
 func testDedupContentExists(t *testing.T, memRedis *redisstub.MemoryRedis, content []byte) {
-	time.Sleep(time.Millisecond * 200) // give background thread time
 	conn, err := memRedis.Dial("")
 	if err != nil {
 		debug.PrintStack()
@@ -97,7 +96,6 @@ func testDedupContentExists(t *testing.T, memRedis *redisstub.MemoryRedis, conte
 // testDedupContentDoesNotExist tests if
 // the given content does not exist in the database
 func testDedupContentDoesNotExist(t *testing.T, memRedis *redisstub.MemoryRedis, content []byte) {
-	time.Sleep(time.Millisecond * 200) // give background thread time
 	conn, err := memRedis.Dial("")
 	if err != nil {
 		debug.PrintStack()
@@ -278,8 +276,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if content == nil {
 		t.Fatal("content should exist now, while received nil-content")
 	}
-	// give database some time to process the async storing
-	time.Sleep(time.Millisecond * 200)
 
 	// content should now be in both storages
 	// as the remote get should have also stored the content locally
@@ -314,8 +310,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give database some time to process the flush
-	time.Sleep(time.Millisecond * 200)
 
 	// let's copy the metadata from storageB to storageA
 	copyTestMetaData(t, vdiskIDB, vdiskIDA, redisProviderB, redisProviderA)
@@ -356,8 +350,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if content == nil {
 		t.Fatal("content should exist now, while received nil-content")
 	}
-	// give database some time to process the async storing
-	time.Sleep(time.Millisecond * 200)
 
 	// and also our direct test should show that
 	// the content now exists in both storages

--- a/nbdserver/ardb/deduped_test.go
+++ b/nbdserver/ardb/deduped_test.go
@@ -229,8 +229,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give database some time to process the flush
-	time.Sleep(time.Millisecond * 200)
 
 	// getting content from storageA should be possible
 	content, err := storageA.Get(testBlockIndex)
@@ -262,8 +260,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give database some time to process the flush
-	time.Sleep(time.Millisecond * 200)
 
 	// copy metadata
 	copyTestMetaData(t, vdiskIDA, vdiskIDB, redisProviderA, redisProviderB)
@@ -280,6 +276,9 @@ func TestGetDedupedRootContent(t *testing.T) {
 	// content should now be in both storages
 	// as the remote get should have also stored the content locally
 	testDedupContentExists(t, memRedisA, testContent)
+
+	// wait until the Get method saves the content async
+	time.Sleep(time.Millisecond * 200)
 	testDedupContentExists(t, memRedisB, testContent)
 
 	// let's store some new content in storageB
@@ -299,8 +298,6 @@ func TestGetDedupedRootContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// give database some time to process the flush
-	time.Sleep(time.Millisecond * 200)
 
 	// flush metadata of storageA first,
 	// so it's reloaded next time fresh from externalStorage,
@@ -354,6 +351,9 @@ func TestGetDedupedRootContent(t *testing.T) {
 	// and also our direct test should show that
 	// the content now exists in both storages
 	testDedupContentExists(t, memRedisB, testContent)
+
+	// wait until the Get method saves the content async
+	time.Sleep(time.Millisecond * 200)
 	testDedupContentExists(t, memRedisA, testContent)
 }
 

--- a/nbdserver/ardb/nondeduped.go
+++ b/nbdserver/ardb/nondeduped.go
@@ -38,12 +38,12 @@ func (ss *nonDedupedStorage) Set(blockIndex int64, content []byte) (err error) {
 	// don't store zero blocks,
 	// and delete existing ones if they already existed
 	if ss.isZeroContent(content) {
-		err = redisSendNow(conn, "DEL", key)
+		_, err = conn.Do("DEL", key)
 		return
 	}
 
 	// content is not zero, so let's (over)write it
-	err = redisSendNow(conn, "SET", key, content)
+	_, err = conn.Do("SET", key, content)
 	return
 }
 
@@ -70,7 +70,7 @@ func (ss *nonDedupedStorage) Merge(blockIndex, offset int64, content []byte) (er
 	copy(origContent[offset:], content)
 
 	// store new content, as the merged version is non-zero
-	err = redisSendNow(conn, "SET", key, origContent)
+	_, err = conn.Do("SET", key, origContent)
 	return
 }
 

--- a/nbdserver/ardb/storage.go
+++ b/nbdserver/ardb/storage.go
@@ -18,18 +18,6 @@ type backendStorage interface {
 	GoBackground(ctx context.Context)
 }
 
-// redisSendNow is a utitlity function used by backendStorage functions,
-// and is similar to redis.Conn.Do, except that we don't read the reply
-func redisSendNow(conn redis.Conn, cmd string, args ...interface{}) (err error) {
-	err = conn.Send(cmd, args...)
-	if err != nil {
-		return
-	}
-
-	err = conn.Flush()
-	return
-}
-
 // redisBytes is a utility function used by backendStorage functions,
 // where we don't want to trigger an error for non-existent (or null) content.
 func redisBytes(reply interface{}, replyErr error) (content []byte, err error) {

--- a/nbdserver/lba/lba.go
+++ b/nbdserver/lba/lba.go
@@ -195,23 +195,43 @@ func (lba *LBA) storeCacheInExternalStorage() (err error) {
 	}
 	defer conn.Close()
 
+	var cmdCount int64
 	lba.cache.Serialize(func(index int64, bytes []byte) (err error) {
 		if bytes != nil {
 			err = conn.Send("HSET", lba.vdiskID, index, bytes)
 		} else {
 			err = conn.Send("HDEL", lba.vdiskID, index)
 		}
+
+		cmdCount++
 		return
 	})
 
 	// Write all sets in output buffer to Redis at once
 	err = conn.Flush()
-	if err == nil {
-		// no need to evict, already serialized them
-		evict := false
-		// clear cache, as we serialized them all
-		lba.cache.Clear(evict)
+	if err != nil {
+		return
 	}
+
+	// read all responses
+	var errors flushError
+	for i := int64(0); i < cmdCount; i++ {
+		_, err = conn.Receive()
+		if err != nil {
+			errors = append(errors, err)
+		}
+	}
+	if len(errors) > 0 {
+		err = errors // return 1+ errors in case we received any
+		return
+	}
+
+	// no need to evict, already serialized them
+	evict := false
+	// clear cache, as we serialized them all
+	lba.cache.Clear(evict)
+
+	// return with no errors, all good
 	return
 }
 
@@ -249,5 +269,18 @@ func (lba *LBA) deleteShardFromExternalStorage(index int64) (err error) {
 
 	_, err = conn.Do("HDEL", lba.vdiskID, index)
 
+	return
+}
+
+// flushError is a collection of errors received,
+// send by the server as a reply on the commands that got flushed to it
+type flushError []error
+
+// Error implements Error.Error
+func (e flushError) Error() (s string) {
+	s = fmt.Sprintf("flush failed because of %d commands: ", len(e))
+	for _, err := range e {
+		s += `"` + err.Error() + `";`
+	}
 	return
 }


### PR DESCRIPTION
What started as a quest in making the unit tests of blockstor more reliable again (see #80), resulted in a check of the current deduped code, and specifically the code regions that required the unit test to use the smelly `time.Sleep`.

**TLDR**: fixes #80 

Because of this:

- the broken `redisSendNow` function is removed, and instead we use the `conn.Do` func, and thus correctly reading the responses, and waiting for the acknowledgement of the server, and returning the resulting error if it exists;
- we receive all replies, that the server send, to acknowledge the executed commands we flush (during the LBA serialization / flush process). This way we only clear the LBA cache, if we for sure flushed successfully, and this way we can also log if any errors did occur;

This is great, as it makes our code a lot saner. As a result it also means we need a lot less `time.Sleep` calls in our code. In fact, most `time.Sleep` calls have disappeared.

Among the eliminated `time.Sleep` calls in the test code, are also those that used to trigger a false Travis CI failure now and then. So that's great!