### PR TITLE
add verbose logging and ledisdb to tlogserver

### DIFF
--- a/redisstub/redis.go
+++ b/redisstub/redis.go
@@ -59,3 +59,8 @@ func (mr *MemoryRedis) Close() {
 	os.Remove(mr.datadir)
 	mr.app.Close()
 }
+
+// Address returns the tcp (local) address of this MemoryRedis server
+func (mr *MemoryRedis) Address() string {
+	return mr.addr
+}

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -22,8 +22,8 @@ var (
 
 // Response defines a response from tlog server
 type Response struct {
-	Status    int8     // status of the call, negatif means failed
-	Sequences []uint64 // flushed sequences number, if any
+	Status    int8     // status of the call, negative means failed
+	Sequences []uint64 // flushed sequences number (optional)
 }
 
 // Client defines a Tlog Client.

--- a/tlog/tlogserver/flusher.go
+++ b/tlog/tlogserver/flusher.go
@@ -41,10 +41,14 @@ func newFlusher(conf *config) (*flusher, error) {
 	pools := make(map[int]*redis.Pool, len(addresses))
 
 	for i, addr := range addresses {
+		// We need to do it, otherwise the redis.Pool.Dial always
+		// use the last address
+		redisAddr := addr
+
 		pools[i] = &redis.Pool{
 			MaxIdle:     3,
 			IdleTimeout: 240 * time.Second,
-			Dial:        func() (redis.Conn, error) { return redis.Dial("tcp", addr) },
+			Dial:        func() (redis.Conn, error) { return redis.Dial("tcp", redisAddr) },
 		}
 	}
 

--- a/tlog/tlogserver/flusher.go
+++ b/tlog/tlogserver/flusher.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 	"sync"
 	"time"
 
@@ -33,10 +32,15 @@ type flusher struct {
 }
 
 func newFlusher(conf *config) (*flusher, error) {
+	addresses, err := conf.ObjStoreServerAddress()
+	if err != nil {
+		return nil, err
+	}
+
 	// create redis pool
-	pools := make(map[int]*redis.Pool, 1+conf.K+conf.M)
-	for i := 0; i < conf.K+conf.M+1; i++ {
-		addr := fmt.Sprintf("%v:%v", conf.firstObjStorAddr, conf.firstObjStorPort+i)
+	pools := make(map[int]*redis.Pool, len(addresses))
+
+	for i, addr := range addresses {
 		pools[i] = &redis.Pool{
 			MaxIdle:     3,
 			IdleTimeout: 240 * time.Second,

--- a/tlog/tlogserver/main.go
+++ b/tlog/tlogserver/main.go
@@ -2,19 +2,39 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
 
+	"github.com/g8os/blockstor/redisstub"
 	log "github.com/glendc/go-mini-log"
 )
 
 type config struct {
-	K                int
-	M                int
-	flushSize        int
-	flushTime        int
-	privKey          string
-	nonce            string
-	firstObjStorPort int
-	firstObjStorAddr string
+	K                 int
+	M                 int
+	flushSize         int
+	flushTime         int
+	privKey           string
+	nonce             string
+	objStoreAddresses []string
+}
+
+// ObjStorServerCount returns the amount of
+// Object Store Servers are required/available/expected.
+func (cfg *config) ObjStorServerCount() int {
+	return cfg.K + cfg.M + 1
+}
+
+func (cfg *config) ObjStoreServerAddress() ([]string, error) {
+	if expected := cfg.ObjStorServerCount(); len(cfg.objStoreAddresses) != expected {
+		return nil, fmt.Errorf(
+			"expected %d objstor servers to be available, while %d servers are available",
+			expected, len(cfg.objStoreAddresses))
+	}
+
+	return cfg.objStoreAddresses, nil
 }
 
 func main() {
@@ -22,20 +42,77 @@ func main() {
 
 	var conf config
 
+	var verbose bool
+	var objstoraddresses string
+
 	flag.IntVar(&port, "port", 11211, "port to listen")
 	flag.IntVar(&conf.flushSize, "flush-size", 25, "flush size")
 	flag.IntVar(&conf.flushTime, "flush-time", 25, "flush time (seconds)")
 	flag.IntVar(&conf.K, "k", 4, "K variable of erasure encoding")
 	flag.IntVar(&conf.M, "m", 2, "M variable of erasure encoding")
-	flag.StringVar(&conf.firstObjStorAddr, "first-objstor-addr", "127.0.0.1", "first objstor addr")
-	flag.IntVar(&conf.firstObjStorPort, "first-objstor-port", 16379, "first objstor port")
+	flag.StringVar(&objstoraddresses, "objstor-addresses", "",
+		"comma seperated list of objstor addresses, if < k+m+1 addresses are given, the missing addresses are assumed to be on the ports following the last given address")
 	flag.StringVar(&conf.privKey, "priv-key", "12345678901234567890123456789012", "private key")
 	flag.StringVar(&conf.nonce, "nonce", "37b8e8a308c354048d245f6d", "hex nonce used for encryption")
+	flag.BoolVar(&verbose, "v", false, "log verbose (debug) statements")
 
 	flag.Parse()
 
-	log.Infof("port=%v\n", port)
-	log.Infof("k=%v, m=%v\n", conf.K, conf.M)
+	// config logger (verbose or not)
+	flags := log.LstdFlags | log.Lshortfile
+	if verbose {
+		flags |= log.LDebug
+	}
+	log.SetFlags(flags)
+
+	log.Debugf("port=%v\n", port)
+	log.Debugf("k=%v, m=%v\n", conf.K, conf.M)
+
+	if objstoraddresses != "" {
+		conf.objStoreAddresses = strings.Split(objstoraddresses, ",")
+	}
+	length := len(conf.objStoreAddresses)
+	expectedLength := conf.ObjStorServerCount()
+
+	if length == 0 {
+		// create in-memory ledisdb servers
+		// if no object store address is given
+		conf.objStoreAddresses = make([]string, expectedLength)
+		for i := range conf.objStoreAddresses {
+			// create in-memory redis
+			objstor := redisstub.NewMemoryRedis()
+			conf.objStoreAddresses[i] = objstor.Address()
+
+			// listen to in-memory redis on new goroutine
+			defer objstor.Close()
+			go objstor.Listen()
+		}
+	} else if length < expectedLength {
+		// parse last given address's host and port
+		lastAddr := conf.objStoreAddresses[length-1]
+		host, rawPort, err := net.SplitHostPort(lastAddr)
+		if err != nil {
+			log.Fatalf("objstor address %s is illegal: %v", lastAddr, err)
+		}
+		port, err := strconv.Atoi(rawPort)
+		if err != nil {
+			log.Fatalf("objstor address %s is illegal: %v", lastAddr, err)
+		}
+		// add the missing servers dynamically
+		// (it is assumed that the missing servers are live on the ports
+		//  following the last server's port)
+		port++
+		portBound := port + (expectedLength - length)
+		for ; port < portBound; port++ {
+			addr := net.JoinHostPort(host, strconv.Itoa(port))
+			log.Debug("add missing objstor server address:", addr)
+			conf.objStoreAddresses = append(conf.objStoreAddresses, addr)
+		}
+	} else if length > expectedLength {
+		log.Fatalf(
+			"too many objstor servers given, only %d are required",
+			expectedLength)
+	}
 
 	// create server
 	server, err := NewServer(port, &conf)


### PR DESCRIPTION
+ fixes issue #92;
+ add verbose logging option (-v flag) to tlogserver;
+ integrate ledisdb and allow to ALL in-memory ledisdb server addresses, ideally for testing;
+ support for multiple objstor addresses to be given, such that not all addresses require consecutive ports;