### PR TITLE
tlog : improve TlogBlock copy.

### DIFF
--- a/tlog/schema/util.go
+++ b/tlog/schema/util.go
@@ -1,0 +1,30 @@
+package schema
+
+// CopyBlock copies content of block 'src' to 'dst'
+func CopyBlock(dst, src *TlogBlock) error {
+	vdiskID, err := src.VdiskID()
+	if err != nil {
+		return err
+	}
+	dst.SetVdiskID(vdiskID)
+
+	dst.SetSequence(src.Sequence())
+	dst.SetLba(src.Lba())
+	dst.SetSize(src.Size())
+
+	hash, err := src.Hash()
+	if err != nil {
+		return err
+	}
+	dst.SetHash(hash)
+
+	data, err := src.Data()
+	if err != nil {
+		return err
+	}
+	dst.SetData(data)
+
+	dst.SetTimestamp(src.Timestamp())
+	dst.SetOperation(src.Operation())
+	return nil
+}

--- a/tlog/tlogserver/server/end_to_end_test.go
+++ b/tlog/tlogserver/server/end_to_end_test.go
@@ -84,6 +84,8 @@ func TestEndToEnd(t *testing.T) {
 
 		blocks, err := agg.Blocks()
 		assert.Nil(t, err)
+
+		assert.Equal(t, conf.FlushSize, blocks.Len())
 		for i := 0; i < blocks.Len(); i++ {
 			block := blocks.At(i)
 

--- a/tlog/tlogserver/server/flusher.go
+++ b/tlog/tlogserver/server/flusher.go
@@ -254,7 +254,10 @@ func (f *flusher) encodeCapnp(vdiskID string, blocks []*schema.TlogBlock, lastHa
 
 	// add blocks
 	for i := 0; i < blockList.Len(); i++ {
-		blockList.Set(i, *blocks[i])
+		block := blockList.At(i)
+		if err := schema.CopyBlock(&block, blocks[i]); err != nil {
+			return nil, err
+		}
 	}
 
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
Fixes #117 

Improve by copy it field by field instead of copy
a whole block.