### PR TITLE
Tlog capnp improvement

### DIFF
--- a/tlog/schema/util.go
+++ b/tlog/schema/util.go
@@ -1,5 +1,12 @@
 package schema
 
+// RawTlogRespLen returns length of raw TlogResponse packet
+func RawTlogRespLen(numSeq int) int {
+	return 1 + // status:uint8
+		(numSeq * 8) + // sequences:uint64
+		40 // capnp overhead. TODO : find the exact number.
+}
+
 // CopyBlock copies content of block 'src' to 'dst'
 func CopyBlock(dst, src *TlogBlock) error {
 	vdiskID, err := src.VdiskID()

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -36,10 +36,11 @@ type Result struct {
 // Client defines a Tlog Client.
 // This client is not thread/goroutine safe
 type Client struct {
-	addr    string
-	vdiskID string
-	conn    *net.TCPConn
-	bw      *bufio.Writer
+	addr            string
+	vdiskID         string
+	conn            *net.TCPConn
+	bw              *bufio.Writer
+	capnpSegmentBuf []byte
 }
 
 // New creates a new tlog client
@@ -164,7 +165,7 @@ func (c *Client) Send(op uint8, seq uint64, lba, timestamp uint64,
 
 	hash := blockstor.HashBytes(data)
 
-	b, err := buildCapnp(c.vdiskID, op, seq, hash[:], lba, timestamp, data, size)
+	b, err := c.buildCapnp(op, seq, hash[:], lba, timestamp, data, size)
 	if err != nil {
 		return err
 	}

--- a/tlog/tlogserver/main.go
+++ b/tlog/tlogserver/main.go
@@ -20,6 +20,7 @@ func main() {
 	flag.StringVar(&conf.ListenAddr, "listen-addr", conf.ListenAddr, "port to listen")
 	flag.IntVar(&conf.FlushSize, "flush-size", conf.FlushSize, "flush size")
 	flag.IntVar(&conf.FlushTime, "flush-time", conf.FlushTime, "flush time (seconds)")
+	flag.IntVar(&conf.BlockSize, "block-size", conf.BlockSize, "block size (bytes)")
 	flag.IntVar(&conf.K, "k", conf.K, "K variable of erasure encoding")
 	flag.IntVar(&conf.M, "m", conf.M, "M variable of erasure encoding")
 	flag.StringVar(&conf.PrivKey, "priv-key", conf.PrivKey, "private key")

--- a/tlog/tlogserver/server/config.go
+++ b/tlog/tlogserver/server/config.go
@@ -18,6 +18,7 @@ func DefaultConfig() *Config {
 		ListenAddr: "0.0.0.0:11211",
 		FlushSize:  25,
 		FlushTime:  25,
+		BlockSize:  4096,
 		PrivKey:    "12345678901234567890123456789012",
 		HexNonce:   "37b8e8a308c354048d245f6d",
 	}
@@ -27,6 +28,7 @@ func DefaultConfig() *Config {
 type Config struct {
 	K                 int
 	M                 int
+	BlockSize         int // size of each block, used as hint for the flusher buffer size
 	ListenAddr        string
 	FlushSize         int
 	FlushTime         int

--- a/tlog/tlogserver/server/flusher.go
+++ b/tlog/tlogserver/server/flusher.go
@@ -183,10 +183,7 @@ func (f *flusher) encodeCapnp(blocks []*schema.TlogBlock, vd *vdisk) ([]byte, er
 
 	err = capnp.NewEncoder(buf).Encode(msg)
 
-	// increase the length of segment buffer
-	if buf.Len() > cap(vd.segmentBuf) {
-		vd.segmentBuf = make([]byte, 0, buf.Len())
-	}
+	vd.resizeSegmentBuf(buf.Len())
 
 	return buf.Bytes(), err
 }

--- a/tlog/tlogserver/server/response.go
+++ b/tlog/tlogserver/server/response.go
@@ -20,8 +20,8 @@ func (r *response) capnpSize() int {
 	return 1 /* status */ + (len(r.Sequences) * 8) /* sequences */ + 30 /* capnp overhead */
 }
 
-func (r *response) toCapnp() (*capnp.Message, error) {
-	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+func (r *response) toCapnp(segmentBuf []byte) (*capnp.Message, error) {
+	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(segmentBuf))
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +46,8 @@ func (r *response) toCapnp() (*capnp.Message, error) {
 	return msg, nil
 }
 
-func (r *response) write(w io.Writer) error {
-	msg, err := r.toCapnp()
+func (r *response) write(w io.Writer, segmentBuf []byte) error {
+	msg, err := r.toCapnp(segmentBuf)
 	if err != nil {
 		return err
 	}

--- a/tlog/tlogserver/server/server.go
+++ b/tlog/tlogserver/server/server.go
@@ -53,6 +53,7 @@ func NewServer(conf *Config) (*Server, error) {
 		}
 	}
 
+	vdiskMgr = newVdiskManager(conf.BlockSize, conf.FlushSize)
 	return &Server{
 		f:                f,
 		ObjStorAddresses: objstorAddrs,
@@ -106,7 +107,7 @@ func (s *Server) handle(conn net.Conn) error {
 		}
 
 		if vd == nil {
-			vd, err = vdiskTab.get(curVdiskID, s.f)
+			vd, err = vdiskMgr.get(curVdiskID, s.f)
 			if err != nil {
 				log.Infof("failed to vdisk: %v, err: %v", curVdiskID, err)
 				return err

--- a/tlog/tlogserver/server/server.go
+++ b/tlog/tlogserver/server/server.go
@@ -80,8 +80,7 @@ func (s *Server) ListenAddr() string {
 }
 
 func (s *Server) handle(conn net.Conn) error {
-	var tlc *tlogChan
-	var vdiskID string
+	var vd *vdisk
 
 	defer conn.Close()
 	for {
@@ -106,32 +105,30 @@ func (s *Server) handle(conn net.Conn) error {
 			return err
 		}
 
-		if tlc == nil {
-			vdiskID = curVdiskID
-
-			tlc, err = s.f.getTlogChan(vdiskID)
+		if vd == nil {
+			vd, err = vdiskTab.get(curVdiskID, s.f)
 			if err != nil {
-				log.Infof("failed to get tlog channel of vdisk: %v, err: %v", vdiskID, err)
+				log.Infof("failed to vdisk: %v, err: %v", curVdiskID, err)
 				return err
 			}
-			go s.sendResp(conn, vdiskID, tlc.respChan)
+			go s.sendResp(conn, vd.vdiskID, vd.respChan)
 		}
 
-		if vdiskID != curVdiskID {
-			err = fmt.Errorf("invalid vdiskID. expected: %v, got: %v", vdiskID, curVdiskID)
+		if vd.vdiskID != curVdiskID {
+			err = fmt.Errorf("invalid vdiskID. expected: %v, got: %v", vd.vdiskID, curVdiskID)
 			log.Info(err)
 			return err
 		}
 
 		// check hash
-		if err := s.hash(tlb, vdiskID); err != nil {
+		if err := s.hash(tlb, vd.vdiskID); err != nil {
 			log.Debugf("hash check failed:%v\n", err)
 			return err
 		}
 
 		// store
-		tlc.inputChan <- tlb
-		tlc.respChan <- &response{
+		vd.inputChan <- tlb
+		vd.respChan <- &response{
 			Status:    0,
 			Sequences: []uint64{tlb.Sequence()},
 		}

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"github.com/g8os/blockstor/tlog/schema"
+	log "github.com/glendc/go-mini-log"
+)
+
+const (
+	respChanSize = 10
+
+	// tlogblock buffer size = flusher.flushSize * tlogBlockFactorSize
+	// With buffer size that bigger than flushSize:
+	// - we don't always block when flushing
+	// - our RAM won't exploded because we still have upper limit
+	tlogBlockFactorSize = 5
+)
+
+var vdiskTab *vdiskTable
+
+func init() {
+	vdiskTab = newVdiskTable()
+}
+
+type vdisk struct {
+	vdiskID    string
+	lastHash   []byte
+	inputChan  chan *schema.TlogBlock
+	respChan   chan *response
+	flusher    *flusher
+	segmentBuf []byte
+}
+
+func newVdisk(vdiskID string, f *flusher) (*vdisk, error) {
+	// get last hash from storage
+	lastHash, err := f.getLastHash(vdiskID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &vdisk{
+		vdiskID:   vdiskID,
+		lastHash:  lastHash,
+		inputChan: make(chan *schema.TlogBlock, f.flushSize*tlogBlockFactorSize),
+		respChan:  make(chan *response, respChanSize),
+		flusher:   f,
+	}, nil
+}
+
+type vdiskTable struct {
+	vdisks map[string]*vdisk
+	lock   sync.Mutex
+}
+
+func newVdiskTable() *vdiskTable {
+	return &vdiskTable{
+		vdisks: map[string]*vdisk{},
+	}
+}
+
+func (vt *vdiskTable) get(vdiskID string, f *flusher) (*vdisk, error) {
+	vt.lock.Lock()
+	defer vt.lock.Unlock()
+
+	vd, ok := vt.vdisks[vdiskID]
+	if !ok {
+		var err error
+		vd, err = newVdisk(vdiskID, f)
+		if err != nil {
+			return nil, err
+		}
+		go vd.Run()
+	}
+
+	return vd, nil
+}
+
+// this is the flusher routine that does the flush asynchronously
+func (vd *vdisk) Run() {
+	var err error
+
+	tlogs := []*schema.TlogBlock{}
+	dur := time.Duration(vd.flusher.flushTime) * time.Second
+	pfTimer := time.NewTimer(dur) // periodic flush timer
+
+	var toFlushLen int
+	for {
+		select {
+		case tlb := <-vd.inputChan:
+			tlogs = append(tlogs, tlb)
+			if len(tlogs)%vd.flusher.flushSize != 0 { // only flush if it reach f.flushSize
+				continue
+			}
+			toFlushLen = vd.flusher.flushSize
+
+			pfTimer.Stop()
+			pfTimer.Reset(dur)
+
+		case <-pfTimer.C:
+			pfTimer.Reset(dur)
+			if len(tlogs) == 0 {
+				continue
+			}
+			toFlushLen = len(tlogs)
+		}
+
+		// get the blocks
+		blocks := tlogs[:toFlushLen]
+		tlogs = tlogs[toFlushLen:]
+
+		var seqs []uint64
+		var status int8
+
+		seqs, err = vd.flusher.flush(blocks[:], vd)
+		if err != nil {
+			log.Infof("flush %v failed: %v", vd.vdiskID, err)
+			status = -1
+		}
+
+		vd.respChan <- &response{
+			Status:    status,
+			Sequences: seqs,
+		}
+	}
+}


### PR DESCRIPTION
- use buffer for the capnp encoding
- for flushing process, limit max len of buffer
