### PR TITLE
Fix capnp prefix

### DIFF
--- a/tlog/capnp_prefix.go
+++ b/tlog/capnp_prefix.go
@@ -1,0 +1,43 @@
+package tlog
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+const (
+	capnpWordLen = 8
+)
+
+// WriteCapnpPrefix writes capnp prefix used in stream message.
+// As described at https://capnproto.org/encoding.html#serialization-over-a-stream
+func WriteCapnpPrefix(w io.Writer, length int) error {
+	var prefix uint32
+
+	if length%capnpWordLen != 0 {
+		return fmt.Errorf("capnp prefix : length should be aligned to: %v. length=%v", capnpWordLen, length)
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, prefix); err != nil { // write zero
+		return err
+	}
+
+	prefix = uint32(length / capnpWordLen)
+
+	return binary.Write(w, binary.LittleEndian, prefix)
+}
+
+// ReadCapnpPrefix reads capnp prefix used in stream message.
+// As described at https://capnproto.org/encoding.html#serialization-over-a-stream
+func ReadCapnpPrefix(rd io.Reader) (segmentNum, length uint32, err error) {
+	if err = binary.Read(rd, binary.LittleEndian, &segmentNum); err != nil {
+		return
+	}
+	if err = binary.Read(rd, binary.LittleEndian, &length); err != nil {
+		return
+	}
+
+	length = length * capnpWordLen
+	return
+}

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -3,7 +3,6 @@ package tlogclient
 import (
 	"bufio"
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/g8os/blockstor"
+	"github.com/g8os/blockstor/tlog"
 )
 
 var (
@@ -175,16 +175,9 @@ func (c *Client) Send(op uint8, seq uint64, lba, timestamp uint64,
 		c.capnpSegmentBuf = make([]byte, 0, len(b))
 	}
 
-	// build capnp prefix as described at https://capnproto.org/encoding.html#serialization-over-a-stream
+	// add capnp prefix
 	buf := new(bytes.Buffer)
-
-	var prefix uint32
-	if err := binary.Write(buf, binary.LittleEndian, prefix); err != nil {
-		return err
-	}
-
-	prefix = uint32(len(b) / 8)
-	if err := binary.Write(buf, binary.LittleEndian, prefix); err != nil {
+	if err := tlog.WriteCapnpPrefix(buf, len(b)); err != nil {
 		return err
 	}
 

--- a/tlog/tlogserver/server/response.go
+++ b/tlog/tlogserver/server/response.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 
+	"github.com/g8os/blockstor/tlog"
 	"github.com/g8os/blockstor/tlog/schema"
 
 	"zombiezen.com/go/capnproto2"
@@ -58,9 +58,9 @@ func (r *response) write(w io.Writer, segmentBuf []byte) error {
 		return err
 	}
 
-	prefix := fmt.Sprintf("%v\r\n", buf.Len())
-
-	w.Write([]byte(prefix))
+	if err := tlog.WriteCapnpPrefix(w, buf.Len()); err != nil {
+		return err
+	}
 
 	_, err = buf.WriteTo(w)
 	return err

--- a/tlog/tlogserver/server/response.go
+++ b/tlog/tlogserver/server/response.go
@@ -15,12 +15,7 @@ type response struct {
 	Sequences []uint64
 }
 
-// count the encoded capnp size object
-func (r *response) capnpSize() int {
-	return 1 /* status */ + (len(r.Sequences) * 8) /* sequences */ + 30 /* capnp overhead */
-}
-
-func (r *response) toCapnp(segmentBuf []byte) (*capnp.Message, error) {
+func (r *response) toCapnp(segmentBuf []byte) ([]byte, error) {
 	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(segmentBuf))
 	if err != nil {
 		return nil, err
@@ -43,25 +38,23 @@ func (r *response) toCapnp(segmentBuf []byte) (*capnp.Message, error) {
 	resp.SetStatus(r.Status)
 	resp.SetSequences(seqs)
 
-	return msg, nil
+	buf := new(bytes.Buffer)
+	if err := capnp.NewEncoder(buf).Encode(msg); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 func (r *response) write(w io.Writer, segmentBuf []byte) error {
-	msg, err := r.toCapnp(segmentBuf)
+	data, err := r.toCapnp(segmentBuf)
 	if err != nil {
 		return err
 	}
 
-	buf := new(bytes.Buffer)
-
-	if err := capnp.NewEncoder(buf).Encode(msg); err != nil {
+	if err := tlog.WriteCapnpPrefix(w, len(data)); err != nil {
 		return err
 	}
 
-	if err := tlog.WriteCapnpPrefix(w, buf.Len()); err != nil {
-		return err
-	}
-
-	_, err = buf.WriteTo(w)
+	_, err = w.Write(data)
 	return err
 }


### PR DESCRIPTION
- change tlog response to use capnp prefix instead redis style prefix
- create generic funcs to read & write capnp prefix.