### PR TITLE
tlog : store last hash array instead of single last hash.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -39,11 +39,13 @@
 		},
 		{
 			"ImportPath": "github.com/garyburd/redigo/internal",
-			"Rev": "d8dbe4d94f15fe89232e0402c6e8a0ddf21af3ab"
+			"Comment": "v1.0.0-26-g4339695",
+			"Rev": "433969511232c397de61b1442f9fd49ec06ae9ba"
 		},
 		{
 			"ImportPath": "github.com/garyburd/redigo/redis",
-			"Rev": "d8dbe4d94f15fe89232e0402c6e8a0ddf21af3ab"
+			"Comment": "v1.0.0-26-g4339695",
+			"Rev": "433969511232c397de61b1442f9fd49ec06ae9ba"
 		},
 		{
 			"ImportPath": "github.com/glendc/gopher-json",

--- a/tlog/constants.go
+++ b/tlog/constants.go
@@ -1,0 +1,6 @@
+package tlog
+
+const (
+	// last hash ardb key prefix
+	LastHashPrefix = "last_hash_"
+)

--- a/vendor/github.com/garyburd/redigo/redis/conn.go
+++ b/vendor/github.com/garyburd/redigo/redis/conn.go
@@ -17,6 +17,7 @@ package redis
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -56,7 +57,7 @@ type conn struct {
 // DialTimeout acts like Dial but takes timeouts for establishing the
 // connection to the server, writing a command and reading a reply.
 //
-// DialTimeout is deprecated.
+// Deprecated: Use Dial with options instead.
 func DialTimeout(network, address string, connectTimeout, readTimeout, writeTimeout time.Duration) (Conn, error) {
 	return Dial(network, address,
 		DialConnectTimeout(connectTimeout),
@@ -75,6 +76,9 @@ type dialOptions struct {
 	dial         func(network, addr string) (net.Conn, error)
 	db           int
 	password     string
+	dialTLS      bool
+	skipVerify   bool
+	tlsConfig    *tls.Config
 }
 
 // DialReadTimeout specifies the timeout for reading a single command reply.
@@ -123,6 +127,22 @@ func DialPassword(password string) DialOption {
 	}}
 }
 
+// DialTLSConfig specifies the config to use when a TLS connection is dialed.
+// Has no effect when not dialing a TLS connection.
+func DialTLSConfig(c *tls.Config) DialOption {
+	return DialOption{func(do *dialOptions) {
+		do.tlsConfig = c
+	}}
+}
+
+// DialTLSSkipVerify to disable server name verification when connecting
+// over TLS. Has no effect when not dialing a TLS connection.
+func DialTLSSkipVerify(skip bool) DialOption {
+	return DialOption{func(do *dialOptions) {
+		do.skipVerify = skip
+	}}
+}
+
 // Dial connects to the Redis server at the given network and
 // address using the specified options.
 func Dial(network, address string, options ...DialOption) (Conn, error) {
@@ -137,6 +157,26 @@ func Dial(network, address string, options ...DialOption) (Conn, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if do.dialTLS {
+		tlsConfig := cloneTLSClientConfig(do.tlsConfig, do.skipVerify)
+		if tlsConfig.ServerName == "" {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				netConn.Close()
+				return nil, err
+			}
+			tlsConfig.ServerName = host
+		}
+
+		tlsConn := tls.Client(netConn, tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			netConn.Close()
+			return nil, err
+		}
+		netConn = tlsConn
+	}
+
 	c := &conn{
 		conn:         netConn,
 		bw:           bufio.NewWriter(netConn),
@@ -162,7 +202,11 @@ func Dial(network, address string, options ...DialOption) (Conn, error) {
 	return c, nil
 }
 
-var pathDBRegexp = regexp.MustCompile(`/(\d)\z`)
+func dialTLS(do *dialOptions) {
+	do.dialTLS = true
+}
+
+var pathDBRegexp = regexp.MustCompile(`/(\d*)\z`)
 
 // DialURL connects to a Redis server at the given URL using the Redis
 // URI scheme. URLs should follow the draft IANA specification for the
@@ -173,7 +217,7 @@ func DialURL(rawurl string, options ...DialOption) (Conn, error) {
 		return nil, err
 	}
 
-	if u.Scheme != "redis" {
+	if u.Scheme != "redis" && u.Scheme != "rediss" {
 		return nil, fmt.Errorf("invalid redis URL scheme: %s", u.Scheme)
 	}
 
@@ -199,15 +243,22 @@ func DialURL(rawurl string, options ...DialOption) (Conn, error) {
 
 	match := pathDBRegexp.FindStringSubmatch(u.Path)
 	if len(match) == 2 {
-		db, err := strconv.Atoi(match[1])
-		if err != nil {
-			return nil, fmt.Errorf("invalid database: %s", u.Path[1:])
+		db := 0
+		if len(match[1]) > 0 {
+			db, err = strconv.Atoi(match[1])
+			if err != nil {
+				return nil, fmt.Errorf("invalid database: %s", u.Path[1:])
+			}
 		}
 		if db != 0 {
 			options = append(options, DialDatabase(db))
 		}
 	} else if u.Path != "" {
 		return nil, fmt.Errorf("invalid database: %s", u.Path[1:])
+	}
+
+	if u.Scheme == "rediss" {
+		options = append([]DialOption{{dialTLS}}, options...)
 	}
 
 	return Dial("tcp", address, options...)

--- a/vendor/github.com/garyburd/redigo/redis/doc.go
+++ b/vendor/github.com/garyburd/redigo/redis/doc.go
@@ -99,15 +99,14 @@
 //
 // Concurrency
 //
-// Connections do not support concurrent calls to the write methods (Send,
-// Flush) or concurrent calls to the read method (Receive). Connections do
-// allow a concurrent reader and writer.
+// Connections support one concurrent caller to the Receive method and one
+// concurrent caller to the Send and Flush methods. No other concurrency is
+// supported including concurrent calls to the Do method.
 //
-// Because the Do method combines the functionality of Send, Flush and Receive,
-// the Do method cannot be called concurrently with the other methods.
-//
-// For full concurrent access to Redis, use the thread-safe Pool to get and
-// release connections from within a goroutine.
+// For full concurrent access to Redis, use the thread-safe Pool to get, use
+// and release a connection from within a goroutine. Connections returned from
+// a Pool have the concurrency restrictions described in the previous
+// paragraph.
 //
 // Publish and Subscribe
 //
@@ -128,7 +127,7 @@
 // send and flush a subscription management command. The receive method
 // converts a pushed message to convenient types for use in a type switch.
 //
-//  psc := redis.PubSubConn{c}
+//  psc := redis.PubSubConn{Conn: c}
 //  psc.Subscribe("example")
 //  for {
 //      switch v := psc.Receive().(type) {
@@ -166,4 +165,13 @@
 //   if _, err := redis.Scan(reply, &value1, &value2); err != nil {
 //      // handle error
 //  }
+//
+// Errors
+//
+// Connection methods return error replies from the server as type redis.Error.
+//
+// Call the connection Err() method to determine if the connection encountered
+// non-recoverable error such as a network error or protocol parsing error. If
+// Err() returns a non-nil value, then the connection is not usable and should
+// be closed.
 package redis

--- a/vendor/github.com/garyburd/redigo/redis/go17.go
+++ b/vendor/github.com/garyburd/redigo/redis/go17.go
@@ -1,0 +1,33 @@
+// +build go1.7
+
+package redis
+
+import "crypto/tls"
+
+// similar cloneTLSClientConfig in the stdlib, but also honor skipVerify for the nil case
+func cloneTLSClientConfig(cfg *tls.Config, skipVerify bool) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{InsecureSkipVerify: skipVerify}
+	}
+	return &tls.Config{
+		Rand:                        cfg.Rand,
+		Time:                        cfg.Time,
+		Certificates:                cfg.Certificates,
+		NameToCertificate:           cfg.NameToCertificate,
+		GetCertificate:              cfg.GetCertificate,
+		RootCAs:                     cfg.RootCAs,
+		NextProtos:                  cfg.NextProtos,
+		ServerName:                  cfg.ServerName,
+		ClientAuth:                  cfg.ClientAuth,
+		ClientCAs:                   cfg.ClientCAs,
+		InsecureSkipVerify:          cfg.InsecureSkipVerify,
+		CipherSuites:                cfg.CipherSuites,
+		PreferServerCipherSuites:    cfg.PreferServerCipherSuites,
+		ClientSessionCache:          cfg.ClientSessionCache,
+		MinVersion:                  cfg.MinVersion,
+		MaxVersion:                  cfg.MaxVersion,
+		CurvePreferences:            cfg.CurvePreferences,
+		DynamicRecordSizingDisabled: cfg.DynamicRecordSizingDisabled,
+		Renegotiation:               cfg.Renegotiation,
+	}
+}

--- a/vendor/github.com/garyburd/redigo/redis/pool.go
+++ b/vendor/github.com/garyburd/redigo/redis/pool.go
@@ -46,40 +46,26 @@ var (
 //
 // The following example shows how to use a pool in a web application. The
 // application creates a pool at application startup and makes it available to
-// request handlers using a global variable.
+// request handlers using a package level variable. The pool configuration used
+// here is an example, not a recommendation.
 //
-//  func newPool(server, password string) *redis.Pool {
-//      return &redis.Pool{
-//          MaxIdle: 3,
-//          IdleTimeout: 240 * time.Second,
-//          Dial: func () (redis.Conn, error) {
-//              c, err := redis.Dial("tcp", server)
-//              if err != nil {
-//                  return nil, err
-//              }
-//              if _, err := c.Do("AUTH", password); err != nil {
-//                  c.Close()
-//                  return nil, err
-//              }
-//              return c, err
-//          },
-//          TestOnBorrow: func(c redis.Conn, t time.Time) error {
-//              _, err := c.Do("PING")
-//              return err
-//          },
-//      }
+//  func newPool(addr string) *redis.Pool {
+//    return &redis.Pool{
+//      MaxIdle: 3,
+//      IdleTimeout: 240 * time.Second,
+//      Dial: func () (redis.Conn, error) { return redis.Dial("tcp", addr) },
+//    }
 //  }
 //
 //  var (
-//      pool *redis.Pool
-//      redisServer = flag.String("redisServer", ":6379", "")
-//      redisPassword = flag.String("redisPassword", "", "")
+//    pool *redis.Pool
+//    redisServer = flag.String("redisServer", ":6379", "")
 //  )
 //
 //  func main() {
-//      flag.Parse()
-//      pool = newPool(*redisServer, *redisPassword)
-//      ...
+//    flag.Parse()
+//    pool = newPool(*redisServer)
+//    ...
 //  }
 //
 // A request handler gets a connection from the pool and closes the connection
@@ -88,13 +74,53 @@ var (
 //  func serveHome(w http.ResponseWriter, r *http.Request) {
 //      conn := pool.Get()
 //      defer conn.Close()
-//      ....
+//      ...
+//  }
+//
+// Use the Dial function to authenticate connections with the AUTH command or
+// select a database with the SELECT command:
+//
+//  pool := &redis.Pool{
+//    // Other pool configuration not shown in this example.
+//    Dial: func () (redis.Conn, error) {
+//      c, err := redis.Dial("tcp", server)
+//      if err != nil {
+//        return nil, err
+//      }
+//      if _, err := c.Do("AUTH", password); err != nil {
+//        c.Close()
+//        return nil, err
+//      }
+//      if _, err := c.Do("SELECT", db); err != nil {
+//        c.Close()
+//        return nil, err
+//      }
+//      return c, nil
+//    }
+//  }
+//
+// Use the TestOnBorrow function to check the health of an idle connection
+// before the connection is returned to the application. This example PINGs
+// connections that have been idle more than a minute:
+//
+//  pool := &redis.Pool{
+//    // Other pool configuration not shown in this example.
+//    TestOnBorrow: func(c redis.Conn, t time.Time) error {
+//      if time.Since(t) < time.Minute {
+//        return nil
+//      }
+//      _, err := c.Do("PING")
+//      return err
+//    },
 //  }
 //
 type Pool struct {
 
 	// Dial is an application supplied function for creating and configuring a
-	// connection
+	// connection.
+	//
+	// The connection returned from Dial must not be in a special state
+	// (subscribed to pubsub channel, transaction started, ...).
 	Dial func() (Conn, error)
 
 	// TestOnBorrow is an optional application supplied function for checking
@@ -116,7 +142,7 @@ type Pool struct {
 	// the timeout to a value less than the server's timeout.
 	IdleTimeout time.Duration
 
-	// If Wait is true and the pool is at the MaxIdle limit, then Get() waits
+	// If Wait is true and the pool is at the MaxActive limit, then Get() waits
 	// for a connection to be returned to the pool before returning.
 	Wait bool
 
@@ -135,8 +161,9 @@ type idleConn struct {
 	t time.Time
 }
 
-// NewPool creates a new pool. This function is deprecated. Applications should
-// initialize the Pool fields directly as shown in example.
+// NewPool creates a new pool.
+//
+// Deprecated: Initialize the Pool directory as shown in the example.
 func NewPool(newFn func() (Conn, error), maxIdle int) *Pool {
 	return &Pool{Dial: newFn, MaxIdle: maxIdle}
 }

--- a/vendor/github.com/garyburd/redigo/redis/pre_go17.go
+++ b/vendor/github.com/garyburd/redigo/redis/pre_go17.go
@@ -1,0 +1,31 @@
+// +build !go1.7
+
+package redis
+
+import "crypto/tls"
+
+// similar cloneTLSClientConfig in the stdlib, but also honor skipVerify for the nil case
+func cloneTLSClientConfig(cfg *tls.Config, skipVerify bool) *tls.Config {
+	if cfg == nil {
+		return &tls.Config{InsecureSkipVerify: skipVerify}
+	}
+	return &tls.Config{
+		Rand:                     cfg.Rand,
+		Time:                     cfg.Time,
+		Certificates:             cfg.Certificates,
+		NameToCertificate:        cfg.NameToCertificate,
+		GetCertificate:           cfg.GetCertificate,
+		RootCAs:                  cfg.RootCAs,
+		NextProtos:               cfg.NextProtos,
+		ServerName:               cfg.ServerName,
+		ClientAuth:               cfg.ClientAuth,
+		ClientCAs:                cfg.ClientCAs,
+		InsecureSkipVerify:       cfg.InsecureSkipVerify,
+		CipherSuites:             cfg.CipherSuites,
+		PreferServerCipherSuites: cfg.PreferServerCipherSuites,
+		ClientSessionCache:       cfg.ClientSessionCache,
+		MinVersion:               cfg.MinVersion,
+		MaxVersion:               cfg.MaxVersion,
+		CurvePreferences:         cfg.CurvePreferences,
+	}
+}

--- a/vendor/github.com/garyburd/redigo/redis/redis.go
+++ b/vendor/github.com/garyburd/redigo/redis/redis.go
@@ -24,10 +24,7 @@ type Conn interface {
 	// Close closes the connection.
 	Close() error
 
-	// Err returns a non-nil value if the connection is broken. The returned
-	// value is either the first non-nil value returned from the underlying
-	// network connection or a protocol parsing error. Applications should
-	// close broken connections.
+	// Err returns a non-nil value when the connection is not usable.
 	Err() error
 
 	// Do sends a command to the server and returns the received reply.

--- a/vendor/github.com/garyburd/redigo/redis/reply.go
+++ b/vendor/github.com/garyburd/redigo/redis/reply.go
@@ -215,7 +215,9 @@ func Bool(reply interface{}, err error) (bool, error) {
 	return false, fmt.Errorf("redigo: unexpected type for Bool, got type %T", reply)
 }
 
-// MultiBulk is deprecated. Use Values.
+// MultiBulk is a helper that converts an array command reply to a []interface{}.
+//
+// Deprecated: Use Values instead.
 func MultiBulk(reply interface{}, err error) ([]interface{}, error) { return Values(reply, err) }
 
 // Values is a helper that converts an array command reply to a []interface{}.
@@ -269,6 +271,36 @@ func Strings(reply interface{}, err error) ([]string, error) {
 		return nil, reply
 	}
 	return nil, fmt.Errorf("redigo: unexpected type for Strings, got type %T", reply)
+}
+
+// ByteSlices is a helper that converts an array command reply to a [][]byte.
+// If err is not equal to nil, then ByteSlices returns nil, err. Nil array
+// items are stay nil. ByteSlices returns an error if an array item is not a
+// bulk string or nil.
+func ByteSlices(reply interface{}, err error) ([][]byte, error) {
+	if err != nil {
+		return nil, err
+	}
+	switch reply := reply.(type) {
+	case []interface{}:
+		result := make([][]byte, len(reply))
+		for i := range reply {
+			if reply[i] == nil {
+				continue
+			}
+			p, ok := reply[i].([]byte)
+			if !ok {
+				return nil, fmt.Errorf("redigo: unexpected element type for ByteSlices, got type %T", reply[i])
+			}
+			result[i] = p
+		}
+		return result, nil
+	case nil:
+		return nil, ErrNil
+	case Error:
+		return nil, reply
+	}
+	return nil, fmt.Errorf("redigo: unexpected type for ByteSlices, got type %T", reply)
 }
 
 // Ints is a helper that converts an array command reply to a []int. If
@@ -358,4 +390,36 @@ func Int64Map(result interface{}, err error) (map[string]int64, error) {
 		m[string(key)] = value
 	}
 	return m, nil
+}
+
+// Positions is a helper that converts an array of positions (lat, long)
+// into a [][2]float64. The GEOPOS command returns replies in this format.
+func Positions(result interface{}, err error) ([]*[2]float64, error) {
+	values, err := Values(result, err)
+	if err != nil {
+		return nil, err
+	}
+	positions := make([]*[2]float64, len(values))
+	for i := range values {
+		if values[i] == nil {
+			continue
+		}
+		p, ok := values[i].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("redigo: unexpected element type for interface slice, got type %T", values[i])
+		}
+		if len(p) != 2 {
+			return nil, fmt.Errorf("redigo: unexpected number of values for a member position, got %d", len(p))
+		}
+		lat, err := Float64(p[0], nil)
+		if err != nil {
+			return nil, err
+		}
+		long, err := Float64(p[1], nil)
+		if err != nil {
+			return nil, err
+		}
+		positions[i] = &[2]float64{lat, long}
+	}
+	return positions, nil
 }

--- a/vendor/github.com/garyburd/redigo/redis/scan.go
+++ b/vendor/github.com/garyburd/redigo/redis/scan.go
@@ -183,6 +183,17 @@ func convertAssign(d interface{}, s interface{}) (err error) {
 				err = convertAssignInt(d.Elem(), s)
 			}
 		}
+	case string:
+		switch d := d.(type) {
+		case *string:
+			*d = s
+		case *interface{}:
+			*d = s
+		case nil:
+			// skip value
+		default:
+			err = cannotConvert(reflect.ValueOf(d), s)
+		}
 	case []interface{}:
 		switch d := d.(type) {
 		case *[]interface{}:
@@ -234,9 +245,9 @@ func Scan(src []interface{}, dest ...interface{}) ([]interface{}, error) {
 }
 
 type fieldSpec struct {
-	name  string
-	index []int
-	//omitEmpty bool
+	name      string
+	index     []int
+	omitEmpty bool
 }
 
 type structSpec struct {
@@ -252,7 +263,7 @@ func compileStructSpec(t reflect.Type, depth map[string]int, index []int, ss *st
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
 		switch {
-		case f.PkgPath != "":
+		case f.PkgPath != "" && !f.Anonymous:
 			// Ignore unexported fields.
 		case f.Anonymous:
 			// TODO: Handle pointers. Requires change to decoder and
@@ -273,8 +284,8 @@ func compileStructSpec(t reflect.Type, depth map[string]int, index []int, ss *st
 				}
 				for _, s := range p[1:] {
 					switch s {
-					//case "omitempty":
-					//  fs.omitempty = true
+					case "omitempty":
+						fs.omitEmpty = true
 					default:
 						panic(fmt.Errorf("redigo: unknown field tag %s for type %s", s, t.Name()))
 					}
@@ -522,6 +533,26 @@ func flattenStruct(args Args, v reflect.Value) Args {
 	ss := structSpecForType(v.Type())
 	for _, fs := range ss.l {
 		fv := v.FieldByIndex(fs.index)
+		if fs.omitEmpty {
+			var empty = false
+			switch fv.Kind() {
+			case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+				empty = fv.Len() == 0
+			case reflect.Bool:
+				empty = !fv.Bool()
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				empty = fv.Int() == 0
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				empty = fv.Uint() == 0
+			case reflect.Float32, reflect.Float64:
+				empty = fv.Float() == 0
+			case reflect.Interface, reflect.Ptr:
+				empty = fv.IsNil()
+			}
+			if empty {
+				continue
+			}
+		}
 		args = append(args, fs.name, fv.Interface())
 	}
 	return args


### PR DESCRIPTION
Part of #131 

idea:

> 
> 
> Only storing one last hash will give us a problem if the last aggregation is failed to be stored to ardb but we already store the new last hash to ardb. We can of course try to roll it back, but the rollback itself might also failed.
> 
> To avoid the need to rollback, we can also only store the new last hash after all pieces successfully stored. But we are going to get performance hit.
> 
> So, storing X last hash is better choice here:
> 
> in normal condition, what we really need is the very last hash.
> if the very last value is not valid, we can use last -1
> if last -1 still not valid, we can use last-2...and so on.
> we need to keep X value to be small to avoid performance issue.
> 