### PR TITLE
suport yaml config in tlog

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -418,3 +418,70 @@ func TestInvalidVdiskTypeDeserialization(t *testing.T) {
 		assert.Error(t, err, "unexpected valid type: %q", invalidType)
 	}
 }
+
+func TestParseValidCSStorageServerConfigStrings(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected []StorageServerConfig
+	}{
+		{"", nil},
+		{",", nil},
+		{",,,,", nil},
+		{"0.0.0.0:1", scconfigs("0.0.0.0:1", 0)},
+		{"0.0.0.0:1 ", scconfigs("0.0.0.0:1", 0)},
+		{" 0.0.0.0:1", scconfigs("0.0.0.0:1", 0)},
+		{" 0.0.0.0:1 ", scconfigs("0.0.0.0:1", 0)},
+		{"0.0.0.0:1@0", scconfigs("0.0.0.0:1", 0)},
+		{"0.0.0.0:1@1", scconfigs("0.0.0.0:1", 1)},
+		{"0.0.0.0:1@1,", scconfigs("0.0.0.0:1", 1)},
+		{"0.0.0.0:1@1,,,,", scconfigs("0.0.0.0:1", 1)},
+		{"0.0.0.0:1,0.0.0.0:1", scconfigs("0.0.0.0:1", 0, "0.0.0.0:1", 0)},
+		{"0.0.0.0:1,0.0.0.0:1,", scconfigs("0.0.0.0:1", 0, "0.0.0.0:1", 0)},
+		{"0.0.0.0:1, 0.0.0.0:1", scconfigs("0.0.0.0:1", 0, "0.0.0.0:1", 0)},
+		{"0.0.0.0:1, 0.0.0.0:1 ", scconfigs("0.0.0.0:1", 0, "0.0.0.0:1", 0)},
+		{"0.0.0.0:1,0.0.0.0:1@1", scconfigs("0.0.0.0:1", 0, "0.0.0.0:1", 1)},
+		{"1.2.3.4:5@6,7.8.9.10:11@12", scconfigs("1.2.3.4:5", 6, "7.8.9.10:11", 12)},
+	}
+
+	for _, testCase := range testCases {
+		serverConfigs, err := ParseCSStorageServerConfigStrings(testCase.input)
+		if assert.Nil(t, err, testCase.input) {
+			assert.Equal(t, testCase.expected, serverConfigs)
+		}
+	}
+}
+
+func TestParseInvalidCSStorageServerConfigStrings(t *testing.T) {
+	testCases := []string{
+		"foo",
+		"localhost",
+		"localhost:foo",
+		"localhost1",
+		"localhost:1@",
+		"localhost:1@foo",
+		"localhost:1localhost:2",
+		"localhost:1,foo",
+		"localhost:1,localhost",
+		"localhost:1,localhost:foo",
+		"localhost:1@foo,localhost:2",
+		"localhost:1,localhost:2@foo",
+	}
+
+	for _, testCase := range testCases {
+		_, err := ParseCSStorageServerConfigStrings(testCase)
+		assert.Error(t, err, testCase)
+	}
+}
+
+// scconfigs allows for quickly generating server configs,
+// for testing purposes
+func scconfigs(argv ...interface{}) (serverConfigs []StorageServerConfig) {
+	argn := len(argv)
+	for i := 0; i < argn; i += 2 {
+		serverConfigs = append(serverConfigs, StorageServerConfig{
+			Address:  argv[i].(string),
+			Database: argv[i+1].(int),
+		})
+	}
+	return
+}

--- a/tlog/redispool.go
+++ b/tlog/redispool.go
@@ -3,63 +3,398 @@ package tlog
 import (
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
 	"sync"
 	"time"
 
+	"github.com/g8os/blockstor/config"
+	"github.com/g8os/blockstor/log"
+	"github.com/g8os/blockstor/redisstub"
 	"github.com/garyburd/redigo/redis"
 )
 
-// RedisPool maintains a collection of premade redis.Pool's,
-// one pool per predefined connection.
-// The application calls the Get method with a valid index
-// to get a connection from the pool and the connection's Close method
-// to return the connection's resources back to the pool.
-//
-// The normal redigo.Pool is not adequate since it only maintains connections for a single server.
-type RedisPool struct {
-	lock          sync.Mutex //protects following
-	pools         map[int]*redis.Pool
-	numberOfPools int
+// AnyRedisPoolFactory creates any kind of RedisPoolFactory based on the given parameters.
+// + if server configs are given, a static RedisPoolFactory will be created;
+//   + if autoFill is true, any missing server configs will be
+//     interfered based on the last given server Config (assuming sequential ports);
+// + if no server configs are given but the configPath is set,
+//   a RedisPoolFactory based on that config file will be created;
+// + if no config path and no server configs are given,
+//   an inmemory redis pool will be created instead;
+func AnyRedisPoolFactory(cfg RedisPoolFactoryConfig) (RedisPoolFactory, error) {
+	if length := len(cfg.ServerConfigs); length > 0 {
+		// one extra (as we require also a metaDataServer)
+		requiredServers := cfg.RequiredDataServerCount + 1
+
+		serverConfigs := cfg.ServerConfigs
+		if length < requiredServers {
+			if !cfg.AutoFill {
+				return nil, errors.New("not enough storage server configs are given")
+			}
+
+			var err error
+			serverConfigs, err = autoFillStorageServerConfigs(requiredServers, serverConfigs)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// more of a dev option:
+		// use the same predefined storage servers for all vdisks
+		return StaticRedisPoolFactory(cfg.RequiredDataServerCount, serverConfigs)
+	}
+
+	// most desired option: config-based storage
+	if cfg.ConfigPath != "" {
+		return ConfigRedisPoolFactory(cfg.RequiredDataServerCount, cfg.ConfigPath)
+	}
+
+	// final resort: inmemory storage
+	return InMemoryRedisPoolFactory(cfg.RequiredDataServerCount), nil
 }
 
-// NewRedisPool creates a new pool for multiple redis servers,
-// the number of pools defined by the number of given connection strings.
-func NewRedisPool(dialConnectionStrings []string) (*RedisPool, error) {
-	numberOfPools := len(dialConnectionStrings)
-	if numberOfPools == 0 {
-		return nil, errors.New("at least one dial connection string is required to create a RedisPool")
+// InMemoryRedisPoolFactory creates a static RedisPoolFactory,
+// which returns the same valid inmemory RedisPool for all vdisks,
+// and thus it will always return a valid RedisPool.
+func InMemoryRedisPoolFactory(requiredDataServerCount int) RedisPoolFactory {
+	return &staticRedisPoolFactory{
+		redisPool: InMemoryRedisPool(requiredDataServerCount),
+	}
+}
+
+// StaticRedisPoolFactory creates a RedisPoolFactory,
+// which returns the same valid RedisPool for all vdisks,
+// and thus it will always return a valid RedisPool.
+// The first storage server is used metadata usage,
+// and the rest of available servers are used as storage servers.
+func StaticRedisPoolFactory(requiredDataServerCount int, storageServers []config.StorageServerConfig) (RedisPoolFactory, error) {
+	redisPool, err := NewRedisPool(requiredDataServerCount, storageServers)
+	if err != nil {
+		return nil, err
 	}
 
-	pools := make(map[int]*redis.Pool, numberOfPools)
-	for index := range dialConnectionStrings {
-		addr := dialConnectionStrings[index]
-		pools[index] = &redis.Pool{
-			MaxActive:   3,
-			MaxIdle:     3,
-			Wait:        true,
-			IdleTimeout: 240 * time.Second,
-			Dial: func() (redis.Conn, error) {
-				return redis.Dial("tcp", addr)
-			},
-		}
+	return &staticRedisPoolFactory{redisPool}, nil
+}
+
+// ConfigRedisPoolFactory creates a RedisPoolFactory
+// using a blockstor config file.
+// The required amount of data servers is specified upfront,
+// such that at creation of a RedisPool, it is validated that the
+// storage cluster in question has sufficient data servers available.
+func ConfigRedisPoolFactory(requiredDataServerCount int, configPath string) (RedisPoolFactory, error) {
+	cfg, err := config.ReadConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create RedisPoolFactory: %s", err.Error())
 	}
 
-	return &RedisPool{
-		pools:         pools,
-		numberOfPools: numberOfPools,
+	return &configRedisPoolFactory{
+		cfg: cfg,
+		requiredDataServerCount: requiredDataServerCount,
 	}, nil
 }
 
-// Get gets a connection. The application must close the returned connection.
-// This method always returns a valid connection so that applications can defer
-// error handling to the first use of the connection. If there is an error
-// getting an underlying connection, then the connection Err, Do, Send, Flush
-// and Receive methods return that error.
-func (p *RedisPool) Get(index int) redis.Conn {
+// AnyRedisPool creates any kind of RedisPool based on the given parameters.
+// + if server configs are given, a RedisPool based on those will be created;
+//   + if autoFill is true, any missing server configs will be
+//     interfered based on the last given server Config (assuming sequential ports);
+// + if no server configs are given but the configPath is set,
+//   a RedisPool will be created from that config file;
+// + if no config path and no server configs are given,
+//   and allowInMemory is true, an inmemory redis pool will be created instead;
+func AnyRedisPool(cfg RedisPoolConfig) (RedisPool, error) {
+	if length := len(cfg.ServerConfigs); length > 0 {
+		// one extra (as we require also a metaDataServer)
+		requiredServers := cfg.RequiredDataServerCount + 1
+
+		serverConfigs := cfg.ServerConfigs
+		if length < requiredServers {
+			if !cfg.AutoFill {
+				return nil, errors.New("not enough storage server configs are given")
+			}
+
+			var err error
+			serverConfigs, err = autoFillStorageServerConfigs(requiredServers, serverConfigs)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// more of a dev option: use predefined storage servers
+		return NewRedisPool(cfg.RequiredDataServerCount, serverConfigs)
+	}
+
+	// most desired option: config-based storage
+	if cfg.ConfigPath != "" {
+		return RedisPoolFromConfig(cfg.ConfigPath, cfg.VdiskID, cfg.RequiredDataServerCount)
+	}
+
+	// more of a test (or dev) option: simply use in-memory storage
+	if cfg.AllowInMemory {
+		return InMemoryRedisPool(cfg.RequiredDataServerCount), nil
+	}
+
+	return nil, errors.New("either a config path or server config has to be given")
+}
+
+// NewRedisPool creates a redis pool using the given servers,
+// seperating the first one for metadata usage,
+// and using the rest as storage servers.
+func NewRedisPool(requiredDataServerCount int, storageServers []config.StorageServerConfig) (RedisPool, error) {
+	if len(storageServers)-1 < requiredDataServerCount {
+		return nil, errors.New("insufficient data servers given")
+	}
+
+	return newRedisPool(storageServers[0], storageServers[1:]), nil
+}
+
+// InMemoryRedisPool creates a redis pool using in-memory
+// ardb storage servers.
+func InMemoryRedisPool(requiredDataServerCount int) RedisPool {
+	var serverConfigs []config.StorageServerConfig
+
+	// one extra for metadata server
+	requiredServers := requiredDataServerCount + 1
+
+	for i := 0; i < requiredServers; i++ {
+		memoryRedis := redisstub.NewMemoryRedis()
+		memoryAddress := memoryRedis.Address()
+
+		go func() {
+			defer func() {
+				log.Debug("closing inmemory storage server: ", memoryAddress)
+				memoryRedis.Close()
+			}()
+			memoryRedis.Listen()
+		}()
+
+		serverConfigs = append(serverConfigs, config.StorageServerConfig{
+			Address:  memoryAddress,
+			Database: 0,
+		})
+	}
+
+	return newRedisPool(serverConfigs[0], serverConfigs[1:])
+}
+
+// RedisPoolFromConfig creates a redis pool for a vdisk,
+// using the storage cluster defined in the given Blokstor config file,
+// for that vdisk.
+func RedisPoolFromConfig(configPath, vdiskID string, requiredDataServerCount int) (RedisPool, error) {
+	cfg, err := config.ReadConfig(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	vdiskcfg, ok := cfg.Vdisks[vdiskID]
+	if !ok {
+		return nil, fmt.Errorf("no vdisk config could be found for %s", vdiskID)
+	}
+
+	if vdiskcfg.TlogStoragecluster == "" {
+		return nil, fmt.Errorf("no tlog storage cluster defined for %s", vdiskID)
+	}
+
+	// should always be found, as this is validated during config loading
+	storageCluster := cfg.StorageClusters[vdiskcfg.TlogStoragecluster]
+
+	if len(storageCluster.DataStorage) < requiredDataServerCount {
+		return nil, fmt.Errorf("storageCluster of vdisk %s has not enough dataservers", vdiskID)
+	}
+
+	// create redis pool based on the given valid storage cluster
+	return newRedisPool(
+		storageCluster.MetaDataStorage,
+		storageCluster.DataStorage[1:],
+	), nil
+}
+
+// RedisPoolConfig used to create any kind
+// of supported redis pool,
+// based on the properties set in this config.
+// Note that this config should only be used because the choice is made
+// by input given by the user in one way or another.
+// If the choice is known on compile time, use the correct constructor instead.
+type RedisPoolConfig struct {
+	// RequiredDataServerCount is required by all types of
+	// redis pools, in order to validate or create the right amount
+	// of storage servers.
+	RequiredDataServerCount int
+
+	// When ConfigPath is set, and no ServerConfigs have been specified,
+	// the redis pool will be created using the config found on this path.
+	ConfigPath string
+
+	// The vdisk ID to use,
+	// only required in case the config path is given.
+	VdiskID string
+
+	// Create a redis pool straight from these server configs,
+	// the redis pool requires RequiredDataServerCount+1 configs to be specified
+	ServerConfigs []config.StorageServerConfig
+	// AutoFill allows you to automatically complete the server config slice,
+	// in case not enough server configs (RequiredDataServerCount+1) have been given.
+	// Auto filling is done, by assuming that all missing servers are on
+	// the same IP address of the last given server config, using sequential ports,
+	// following the port of that last given server config.
+	AutoFill bool
+
+	// Enable this boolean, in case you want to allow an in-memory redis pool.
+	AllowInMemory bool
+}
+
+// RedisPoolFactoryConfig used to create any kind
+// of supported redis pool factory,
+// based on the properties set in this config.
+// Note that this config should only be used because the choice is made
+// by input given by the user in one way or another.
+// If the choice is known on compile time, use the correct constructor instead.
+type RedisPoolFactoryConfig struct {
+	// RequiredDataServerCount is required by all types of
+	// redis pool factories, in order to validate or create the right amount
+	// of storage servers.
+	RequiredDataServerCount int
+
+	// When ConfigPath is set, and no ServerConfigs have been specified,
+	// the redis pool factory will be created using the config found on this path.
+	ConfigPath string
+
+	// Create a redis pool factory straight from these server configs,
+	// the redis pool factor) requires RequiredDataServerCount+1 configs to be specified
+	ServerConfigs []config.StorageServerConfig
+	// AutoFill allows you to automatically complete the server config slice,
+	// in case not enough server configs (RequiredDataServerCount+1) have been given.
+	// Auto filling is done, by assuming that all missing servers are on
+	// the same IP address of the last given server config, using sequential ports,
+	// following the port of that last given server config.
+	AutoFill bool
+
+	// Enable this boolean, in case you want to allow an in-memory redis pool (factory).
+	AllowInMemory bool
+}
+
+// RedisPoolFactory creates a redis pool for a given vdisk.
+type RedisPoolFactory interface {
+	// NewRedisPool creates a new redis pool for the given vdisk.
+	// An error is returned in case that vdisk couldn't be found,
+	// or in case that vdisk has not enough (n < k+m) dataservers linked to it,
+	// in order to create a valid RedisPool.
+	NewRedisPool(vdiskID string) (RedisPool, error)
+}
+
+// RedisPool maintains a collection of premade redis.Pool's,
+// one pool per predefined (meta)data connection.
+type RedisPool interface {
+	// returns amount of DataConnection servers available
+	DataConnectionCount() int
+	// The application calls the DataConnection with a valid index
+	// to get a connection from the pool of data servers.
+	// It is important that the caller of this function closes the
+	// received connection to return the connection's resources back to the pool.
+	DataConnection(index int) redis.Conn
+	// The application calls the MetadataConnection
+	// to get a connection from the metadataServer pool.
+	// It is important that the caller of this function closes the
+	// received connection to return the connection's resources back to the pool.
+	MetadataConnection() redis.Conn
+	// Close all open resources.
+	Close()
+}
+
+type staticRedisPoolFactory struct {
+	redisPool RedisPool
+}
+
+// NewRedisPool implements RedisPoolFactory.NewRedisPool
+func (factory *staticRedisPoolFactory) NewRedisPool(string) (RedisPool, error) {
+	return factory.redisPool, nil
+}
+
+type configRedisPoolFactory struct {
+	cfg                     *config.Config
+	requiredDataServerCount int
+}
+
+// NewRedisPool implements RedisPoolFactory.NewRedisPool
+func (factory *configRedisPoolFactory) NewRedisPool(vdiskID string) (RedisPool, error) {
+	vdiskcfg, ok := factory.cfg.Vdisks[vdiskID]
+	if !ok {
+		return nil, fmt.Errorf("no vdisk config could be found for %s", vdiskID)
+	}
+
+	if vdiskcfg.TlogStoragecluster == "" {
+		return nil, fmt.Errorf("no tlog storage cluster defined for %s", vdiskID)
+	}
+
+	// should always be found, as this is validated during config loading
+	storageCluster := factory.cfg.StorageClusters[vdiskcfg.TlogStoragecluster]
+
+	if len(storageCluster.DataStorage) < factory.requiredDataServerCount {
+		return nil, fmt.Errorf("storageCluster of vdisk %s has not enough dataservers", vdiskID)
+	}
+
+	// create redis pool based on the given valid storage cluster
+	return newRedisPool(
+		storageCluster.MetaDataStorage,
+		storageCluster.DataStorage[:factory.requiredDataServerCount-1],
+	), nil
+}
+
+// redisPool is the internal structure used as the RedisPool
+// in development/production code.
+type redisPool struct {
+	lock         sync.Mutex //protects following
+	dataPools    map[int]*redis.Pool
+	metaDataPool *redis.Pool
+}
+
+// newRedisPool creates a new pool for multiple redis servers,
+// the number of pools defined by the number of given connection strings.
+func newRedisPool(metadataServer config.StorageServerConfig, dataServers []config.StorageServerConfig) RedisPool {
+	dataPools := make(map[int]*redis.Pool, len(dataServers))
+	for index, dataServerConfig := range dataServers {
+		dataPools[index] = newConnectionPool(dataServerConfig)
+	}
+
+	return &redisPool{
+		dataPools:    dataPools,
+		metaDataPool: newConnectionPool(metadataServer),
+	}
+}
+
+// newConnectionPool creates a connection based on a given
+func newConnectionPool(cfg config.StorageServerConfig) *redis.Pool {
+	return &redis.Pool{
+		MaxActive:   3,
+		MaxIdle:     3,
+		Wait:        true,
+		IdleTimeout: 240 * time.Second,
+		Dial: func() (redis.Conn, error) {
+			return redis.Dial("tcp", cfg.Address, redis.DialDatabase(cfg.Database))
+		},
+	}
+}
+
+// MetadataConnection implements RedisPool.MetadataConnection
+func (p *redisPool) MetadataConnection() redis.Conn {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return p.metaDataPool.Get()
+}
+
+// DataConnectionCount implements RedisPool.DataConnectionCount
+func (p *redisPool) DataConnectionCount() int {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	return len(p.dataPools)
+}
+
+// DataConnection implements RedisPool.DataConnection
+func (p *redisPool) DataConnection(index int) redis.Conn {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	if pool, ok := p.pools[index]; ok {
+	if pool, ok := p.dataPools[index]; ok {
 		return pool.Get()
 	}
 
@@ -68,16 +403,17 @@ func (p *RedisPool) Get(index int) redis.Conn {
 	}
 }
 
-// Close releases the resources used by the pool.
-func (p *RedisPool) Close() {
+// Close implements RedisPool.Close
+func (p *redisPool) Close() {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	for _, c := range p.pools {
+	for _, c := range p.dataPools {
 		c.Close()
 	}
+	p.metaDataPool.Close()
 
-	p.pools, p.numberOfPools = nil, 0
+	p.dataPools, p.metaDataPool = nil, nil
 }
 
 // errorConnection taken from
@@ -90,3 +426,36 @@ func (ec errorConnection) Err() error                                     { retu
 func (ec errorConnection) Close() error                                   { return ec.err }
 func (ec errorConnection) Flush() error                                   { return ec.err }
 func (ec errorConnection) Receive() (interface{}, error)                  { return nil, ec.err }
+
+// adds any missing storage server configs based on the last given storage server config
+func autoFillStorageServerConfigs(requiredServers int, serverConfigs []config.StorageServerConfig) ([]config.StorageServerConfig, error) {
+	length := len(serverConfigs)
+	if length >= requiredServers {
+		return serverConfigs[:requiredServers-1], nil
+	}
+
+	lastAddr := serverConfigs[length-1].Address
+	host, rawPort, err := net.SplitHostPort(lastAddr)
+	if err != nil {
+		return nil, fmt.Errorf("storage address %s is illegal: %v", lastAddr, err)
+	}
+	port, err := strconv.Atoi(rawPort)
+	if err != nil {
+		return nil, fmt.Errorf("storage address %s is illegal: %v", lastAddr, err)
+	}
+	// add the missing servers dynamically
+	// (it is assumed that the missing servers are live on the ports
+	//  following the last server's port)
+	port++
+	portBound := port + (requiredServers - length)
+	for ; port < portBound; port++ {
+		addr := net.JoinHostPort(host, strconv.Itoa(port))
+		log.Debug("add missing objstor server address:", addr)
+		serverConfigs = append(serverConfigs, config.StorageServerConfig{
+			Address:  addr,
+			Database: 0,
+		})
+	}
+
+	return serverConfigs, nil
+}

--- a/tlog/status.go
+++ b/tlog/status.go
@@ -59,6 +59,10 @@ func (status HandshakeStatus) Error() error {
 	switch status {
 	case HandshakeStatusInvalidVdiskID:
 		return errors.New("given vdisk is not accepted by the server")
+	case HandshakeStatusInternalServerError:
+		return errors.New("internal server error")
+	case HandshakeStatusInsufficientDataServers:
+		return errors.New("insufficient data servers available")
 	case HandshakeStatusInvalidVersion:
 		return errors.New("client version is not compatible with server")
 	default:
@@ -68,6 +72,12 @@ func (status HandshakeStatus) Error() error {
 
 // Handshake status values
 const (
+	// returned when something went wrong internally
+	// in the tlogserver during the handshake phase
+	HandshakeStatusInternalServerError HandshakeStatus = -4
+	// returned when there are not enough data servers
+	// available to store the data
+	HandshakeStatusInsufficientDataServers HandshakeStatus = -3
 	// returned when the given VdiskID is not legal
 	// could be because it's not valid, or because it already
 	// exists on the server

--- a/tlog/tlogserver/server/config.go
+++ b/tlog/tlogserver/server/config.go
@@ -1,15 +1,5 @@
 package server
 
-import (
-	"errors"
-	"fmt"
-	"net"
-	"strconv"
-
-	"github.com/g8os/blockstor/log"
-	"github.com/g8os/blockstor/redisstub"
-)
-
 // DefaultConfig creates a new config, using sane defaults
 func DefaultConfig() *Config {
 	return &Config{
@@ -26,95 +16,38 @@ func DefaultConfig() *Config {
 
 // Config used for creating the tlogserver
 type Config struct {
-	K                int
-	M                int
-	BlockSize        int // size of each block, used as hint for the flusher buffer size
-	ListenAddr       string
-	FlushSize        int
-	FlushTime        int
-	PrivKey          string
-	HexNonce         string
-	StorageAddresses []string
+	K          int
+	M          int
+	BlockSize  int // size of each block, used as hint for the flusher buffer size
+	ListenAddr string
+	FlushSize  int
+	FlushTime  int
+	PrivKey    string
+	HexNonce   string
 }
 
-// ValidateAndCreateStorageAddresses checks if the config
-// contains exactly as many storage server addresses as expected.
-// If more are given, an error is returned.
-// If none are given, memorystubs can be created if `allowInMemoryStubs` is true, otherwise an error is returned.
-// If less are given, the missing addresses are generated, using consecutive ports,
-// starting with the port following the port of the last given storage server address
-func (cfg *Config) ValidateAndCreateStorageAddresses(allowInMemoryStubs bool) error {
-	length := len(cfg.StorageAddresses)
-	expectedLength := cfg.StorageServerCount()
-
-	if length == 0 {
-		if !allowInMemoryStubs {
-			return errors.New("no storage servers available, and inmemory stubs aren't allowed")
-		}
-
-		// create in-memory ledisdb servers
-		// if no object store address is given
-		cfg.StorageAddresses = make([]string, expectedLength)
-		for i := range cfg.StorageAddresses {
-			// create in-memory redis
-			stor := redisstub.NewMemoryRedis()
-			cfg.StorageAddresses[i] = stor.Address()
-
-			// listen to in-memory redis on new goroutine
-			//defer stor.Close()
-			go stor.Listen()
-		}
-	} else if length < expectedLength {
-		// parse last given address's host and port
-		lastAddr := cfg.StorageAddresses[length-1]
-		host, rawPort, err := net.SplitHostPort(lastAddr)
-		if err != nil {
-			return fmt.Errorf("storage address %s is illegal: %v", lastAddr, err)
-		}
-		port, err := strconv.Atoi(rawPort)
-		if err != nil {
-			return fmt.Errorf("storage address %s is illegal: %v", lastAddr, err)
-		}
-		// add the missing servers dynamically
-		// (it is assumed that the missing servers are live on the ports
-		//  following the last server's port)
-		port++
-		portBound := port + (expectedLength - length)
-		for ; port < portBound; port++ {
-			addr := net.JoinHostPort(host, strconv.Itoa(port))
-			log.Debug("add missing objstor server address:", addr)
-			cfg.StorageAddresses = append(cfg.StorageAddresses, addr)
-		}
-	} else if length > expectedLength {
-		return fmt.Errorf(
-			"too many storage servers given, only %d are required",
-			expectedLength)
-	}
-
-	return nil
+// RequiredDataServers returns how many data servers are required,
+// based on the K and M values.
+func (conf *Config) RequiredDataServers() int {
+	return conf.K + conf.M
 }
 
-// StorageServerCount returns the amount of
-// Storage Servers are required/available/expected.
-func (cfg *Config) StorageServerCount() int {
-	return cfg.K + cfg.M + 1
-}
-
-// StorageServerAddresses returns the storage server addresses,
-// if the config defines exactly as many of the expected server addresses
-func (cfg *Config) StorageServerAddresses() ([]string, error) {
-	if expected := cfg.StorageServerCount(); len(cfg.StorageAddresses) != expected {
-		return nil, fmt.Errorf(
-			"expected %d objstor servers to be available, while %d servers are available",
-			expected, len(cfg.StorageAddresses))
-	}
-
-	return cfg.StorageAddresses, nil
-}
-
-// ConnectionConfig is given by the client to the server,
+// connectionConfig is created using the info
+// given by the client to the server,
 // during the handshake phase.
-type ConnectionConfig struct {
+type connectionConfig struct {
 	VdiskID       string
 	FirstSequence uint64
+	Flusher       *flusher
+}
+
+// flusherConfig is used by the server to create a flusher
+// for a specific vdisk.
+type flusherConfig struct {
+	K         int
+	M         int
+	FlushSize int
+	FlushTime int
+	PrivKey   string
+	HexNonce  string
 }


### PR DESCRIPTION
+ fixes #170;
+ tlog.RedisPool is now an interface;
+ tlog.RedisPool API has changed, splitting Get(index) into a metadata and data method;
+ A tlog.RedisPool can now be created using MemoryRedis, Blockstor Config and simply giving the addresses (as was already supported);
+ flusher is now created during handshake phase;
+ tlog.RedisPool is now created during handshake phase (before flusher is created), using the new tlog.RedisPoolFactory interface;
+ all code interacting with tlog and tlog testcode has been modified to adapt to this change;