### PR TITLE
tlog client : fix reconnect in regard to handshaking

### DIFF
--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -255,7 +255,7 @@ func (c *Client) send(op uint8, seq, lba, timestamp uint64,
 		// the network connection or the tlog server that need time to be recovered.
 		time.Sleep(time.Duration(i) * sendSleepTime)
 
-		if err = c.connect(0); err != nil {
+		if err = c.connect(c.blockBuffer.MinSequence()); err != nil {
 			okToSend = false
 		} else {
 			okToSend = true

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -15,8 +15,11 @@ import (
 	"github.com/g8os/blockstor/tlog/tlogclient/blockbuffer"
 )
 
-var (
-	resendTimeoutDur = 5 * time.Second // duration to wait before re-send the tlog.
+const (
+	sendRetryNum     = 5
+	sendSleepTime    = 500 * time.Millisecond // sleep duration before retrying the Send
+	resendTimeoutDur = 5 * time.Second        // duration to wait before re-send the tlog.
+	readTimeout      = 5 * time.Second
 )
 
 // Response defines a response from tlog server
@@ -41,9 +44,16 @@ type Client struct {
 	bw              *bufio.Writer
 	blockBuffer     *blockbuffer.Buffer
 	capnpSegmentBuf []byte
-	lock            sync.RWMutex
-	ctx             context.Context
-	cancelFunc      context.CancelFunc
+
+	// write lock, to protect against parallel Send
+	// which is not goroutine safe yet
+	wLock sync.RWMutex
+
+	// read lock, to protect it from race condition
+	// caused by 'handshake' and recvOne
+	rLock      sync.RWMutex
+	ctx        context.Context
+	cancelFunc context.CancelFunc
 }
 
 // New creates a new tlog client.
@@ -135,6 +145,13 @@ func (c *Client) Recv(chanSize int) <-chan *Result {
 	go func() {
 		for {
 			tr, err := c.recvOne()
+
+			// it is timeout error
+			// client can't really read something
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+				continue
+			}
+
 			if tr != nil && len(tr.Sequences) > 0 {
 				status := tlog.BlockStatus(tr.Status)
 				seq := tr.Sequences[0]
@@ -169,6 +186,13 @@ func (c *Client) Recv(chanSize int) <-chan *Result {
 
 // recvOne receive one response
 func (c *Client) recvOne() (*Response, error) {
+	c.rLock.Lock()
+	defer c.rLock.Unlock()
+
+	// set read deadline, so we don't have deadlock
+	// for rLock
+	c.conn.SetReadDeadline(time.Now().Add(readTimeout))
+
 	// decode capnp and build response
 	tr, err := c.decodeBlockResponse()
 	if err != nil {
@@ -190,6 +214,9 @@ func (c *Client) recvOne() (*Response, error) {
 }
 
 func (c *Client) createConn() error {
+	c.rLock.Lock()
+	defer c.rLock.Unlock()
+
 	tcpAddr, err := net.ResolveTCPAddr("tcp", c.addr)
 	if err != nil {
 		return err
@@ -212,8 +239,8 @@ func (c *Client) createConn() error {
 // - failed to recover from broken network connection.
 func (c *Client) Send(op uint8, seq, lba, timestamp uint64,
 	data []byte, size uint64) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.wLock.Lock()
+	defer c.wLock.Unlock()
 
 	block, err := c.send(op, seq, lba, timestamp, data, size)
 	if err == nil && block != nil {
@@ -256,6 +283,7 @@ func (c *Client) send(op uint8, seq, lba, timestamp uint64,
 		time.Sleep(time.Duration(i) * sendSleepTime)
 
 		if err = c.connect(c.blockBuffer.MinSequence()); err != nil {
+			log.Infof("tlog client : reconnect attemp(%v) failed:%v", i, err)
 			okToSend = false
 		} else {
 			okToSend = true
@@ -269,8 +297,3 @@ func (c *Client) Close() error {
 	c.cancelFunc()
 	return c.conn.Close()
 }
-
-const (
-	sendRetryNum  = 3
-	sendSleepTime = 500 * time.Millisecond
-)

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -88,6 +88,7 @@ func (vt *vdiskManager) get(vdiskID string, f *flusher, firstSequence uint64) (*
 		if err != nil {
 			return nil, false, err
 		}
+		log.Debugf("create vdisk with expectedSequence:%v", vd.expectedSequence)
 		go vd.runFlusher()
 		go vd.runReceiver()
 	}


### PR DESCRIPTION
Fixes #174

- also send handshake when reconnecting. This why in #174 tlog server complained about unsupported version. Because the client indeed didn't send handshake message at all
- Fix race condition between handshake and receiver thread. 'Recv' is reading from socket continuously, while the handshaking also need to read from it.

`send_tlog` example also improved to wait for tlogs to be flushed before exiting.