### PR TITLE
Tlog metadata redundancy

### DIFF
--- a/tlog/redispool.go
+++ b/tlog/redispool.go
@@ -24,16 +24,14 @@ import (
 //   an inmemory redis pool will be created instead;
 func AnyRedisPoolFactory(cfg RedisPoolFactoryConfig) (RedisPoolFactory, error) {
 	if length := len(cfg.ServerConfigs); length > 0 {
-		requiredServers := cfg.RequiredDataServerCount
-
 		serverConfigs := cfg.ServerConfigs
-		if length < requiredServers {
+		if length < cfg.RequiredDataServerCount {
 			if !cfg.AutoFill {
 				return nil, errors.New("not enough storage server configs are given")
 			}
 
 			var err error
-			serverConfigs, err = autoFillStorageServerConfigs(requiredServers, serverConfigs)
+			serverConfigs, err = autoFillStorageServerConfigs(cfg.RequiredDataServerCount, serverConfigs)
 			if err != nil {
 				return nil, err
 			}
@@ -101,16 +99,14 @@ func ConfigRedisPoolFactory(requiredDataServerCount int, configPath string) (Red
 //   and allowInMemory is true, an inmemory redis pool will be created instead;
 func AnyRedisPool(cfg RedisPoolConfig) (RedisPool, error) {
 	if length := len(cfg.ServerConfigs); length > 0 {
-		requiredServers := cfg.RequiredDataServerCount
-
 		serverConfigs := cfg.ServerConfigs
-		if length < requiredServers {
+		if length < cfg.RequiredDataServerCount {
 			if !cfg.AutoFill {
 				return nil, errors.New("not enough storage server configs are given")
 			}
 
 			var err error
-			serverConfigs, err = autoFillStorageServerConfigs(requiredServers, serverConfigs)
+			serverConfigs, err = autoFillStorageServerConfigs(cfg.RequiredDataServerCount, serverConfigs)
 			if err != nil {
 				return nil, err
 			}
@@ -147,9 +143,7 @@ func NewRedisPool(requiredDataServerCount int, storageServers []config.StorageSe
 func InMemoryRedisPool(requiredDataServerCount int) RedisPool {
 	var serverConfigs []config.StorageServerConfig
 
-	requiredServers := requiredDataServerCount
-
-	for i := 0; i < requiredServers; i++ {
+	for i := 0; i < requiredDataServerCount; i++ {
 		memoryRedis := redisstub.NewMemoryRedis()
 		memoryAddress := memoryRedis.Address()
 

--- a/tlog/tlogclient/decoder/decoder.go
+++ b/tlog/tlogclient/decoder/decoder.go
@@ -219,7 +219,7 @@ func (d *Decoder) getAllPieces(key []byte) ([]byte, error) {
 
 // get last hash of a vdisk
 func (d *Decoder) getLastHash() ([]byte, error) {
-	return GetLastHash(d.pool, d.vdiskID)
+	return d.GetLastHash()
 }
 
 func (d *Decoder) decodeCapnp(data []byte) (*schema.TlogAggregation, error) {

--- a/tlog/tlogclient/decoder/decoder.go
+++ b/tlog/tlogclient/decoder/decoder.go
@@ -219,10 +219,7 @@ func (d *Decoder) getAllPieces(key []byte) ([]byte, error) {
 
 // get last hash of a vdisk
 func (d *Decoder) getLastHash() ([]byte, error) {
-	rc := d.pool.MetadataConnection()
-	defer rc.Close()
-
-	return GetLastHash(rc, d.vdiskID)
+	return GetLastHash(d.pool, d.vdiskID)
 }
 
 func (d *Decoder) decodeCapnp(data []byte) (*schema.TlogAggregation, error) {

--- a/tlog/tlogclient/decoder/last_hash.go
+++ b/tlog/tlogclient/decoder/last_hash.go
@@ -11,7 +11,6 @@ import (
 
 var (
 	// ErrNilLastHash indicates that there is no last hash entry
-	// in the metadata storage.
 	ErrNilLastHash = errors.New("nil last hash")
 )
 
@@ -22,33 +21,86 @@ func GetLashHashKey(vdiskID string) []byte {
 }
 
 // GetLastHash returns valid last hash of a vdisk.
-func GetLastHash(pool tlog.RedisPool, vdiskID string) ([]byte, error) {
-	return getLastHashFromShard(pool, 1, vdiskID)
+// It checks all data shards to get latest valid hash
+func (d *Decoder) GetLastHash() ([]byte, error) {
+	latests := map[uint64][]byte{}
+
+	// get all valid hashes from all data storages
+	for i := 0; i < d.k+d.m; i++ {
+		hash, lastSeq, err := d.getLastHashFromShard(i)
+		if err == nil {
+			latests[lastSeq] = hash
+		}
+	}
+
+	// no hash found, return Nil
+	if len(latests) == 0 {
+		return nil, ErrNilLastHash
+	}
+
+	// get the latest valid hash
+	var maxSeq uint64
+	var lastHash []byte
+	for seq, hash := range latests {
+		if seq > maxSeq {
+			maxSeq = seq
+			lastHash = hash
+		}
+	}
+
+	return lastHash, nil
 }
 
-func getLastHashFromShard(pool tlog.RedisPool, idx int, vdiskID string) ([]byte, error) {
-	rc := pool.DataConnection(idx)
-	key := GetLashHashKey(vdiskID)
+// get a valid last hash from a shard
+func (d *Decoder) getLastHashFromShard(idx int) ([]byte, uint64, error) {
+	rc := d.pool.DataConnection(idx)
+	defer rc.Close()
+
+	key := GetLashHashKey(d.vdiskID)
 
 	hashes, err := redis.ByteSlices(rc.Do("LRANGE", key, 0, -1))
 	if err == redis.ErrNil {
-		return nil, ErrNilLastHash
+		return nil, 0, ErrNilLastHash
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if len(hashes) == 0 {
-		return nil, ErrNilLastHash
+		return nil, 0, ErrNilLastHash
 	}
 
 	// check that the hash really valid
 	for _, hash := range hashes {
-		if _, err := rc.Do("GET", hash); err == nil {
-			return hash, nil
+		if seq, err := d.checkLastHash(hash); err == nil {
+			return hash, seq, nil
 		}
 	}
 
-	return nil, fmt.Errorf("no valid hash for vdiskID: %s", vdiskID)
+	return nil, 0, fmt.Errorf("no valid hash for vdiskID: %s", d.vdiskID)
+}
+
+// make sure that a last hash value is valid
+func (d *Decoder) checkLastHash(hash []byte) (uint64, error) {
+	agg, err := d.get(hash)
+	if err != nil {
+		return 0, err
+	}
+
+	var lastSeq uint64
+
+	// check latest sequence
+	blocks, err := agg.Blocks()
+	if blocks.Len() == 0 {
+		return 0, fmt.Errorf("empty block")
+	}
+
+	for i := 0; i < blocks.Len(); i++ {
+		block := blocks.At(i)
+		if block.Sequence() > lastSeq {
+			lastSeq = block.Sequence()
+		}
+	}
+	return lastSeq, nil
 }

--- a/tlog/tlogclient/decoder/last_hash.go
+++ b/tlog/tlogclient/decoder/last_hash.go
@@ -15,9 +15,20 @@ var (
 	ErrNilLastHash = errors.New("nil last hash")
 )
 
+// GetLashHashKey returns last hash key of
+// a given vdisk ID
+func GetLashHashKey(vdiskID string) []byte {
+	return []byte(tlog.LastHashPrefix + vdiskID)
+}
+
 // GetLastHash returns valid last hash of a vdisk.
-func GetLastHash(rc redis.Conn, vdiskID string) ([]byte, error) {
-	key := tlog.LastHashPrefix + vdiskID
+func GetLastHash(pool tlog.RedisPool, vdiskID string) ([]byte, error) {
+	return getLastHashFromShard(pool, 1, vdiskID)
+}
+
+func getLastHashFromShard(pool tlog.RedisPool, idx int, vdiskID string) ([]byte, error) {
+	rc := pool.DataConnection(idx)
+	key := GetLashHashKey(vdiskID)
 
 	hashes, err := redis.ByteSlices(rc.Do("LRANGE", key, 0, -1))
 	if err == redis.ErrNil {

--- a/tlog/tlogserver/server/flusher.go
+++ b/tlog/tlogserver/server/flusher.go
@@ -245,7 +245,7 @@ func (f *flusher) store(idx int, hash, lastHashKey, data []byte) errStore {
 		return es
 	}
 
-	// flush the command
+	// flush the commands
 	if err := rc.Flush(); err != nil {
 		es.errSend = err
 		return es

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -9,6 +9,7 @@ import (
 	"github.com/g8os/blockstor/log"
 	"github.com/g8os/blockstor/tlog"
 	"github.com/g8os/blockstor/tlog/schema"
+	"github.com/g8os/blockstor/tlog/tlogclient/decoder"
 )
 
 const (
@@ -25,7 +26,8 @@ var vdiskMgr *vdiskManager
 
 type vdisk struct {
 	vdiskID          string
-	lastHash         []byte
+	lastHash         []byte // current in memory last hash
+	lastHashKey      []byte
 	inputChan        chan *schema.TlogBlock // input channel received from client
 	orderedChan      chan *schema.TlogBlock // ordered blocks from inputChan
 	respChan         chan *blockResponse
@@ -47,6 +49,7 @@ func newVdisk(vdiskID string, f *flusher, firstSequence uint64) (*vdisk, error) 
 
 	return &vdisk{
 		vdiskID:          vdiskID,
+		lastHashKey:      decoder.GetLashHashKey(vdiskID),
 		lastHash:         lastHash,
 		inputChan:        make(chan *schema.TlogBlock, maxTlbInBuffer),
 		orderedChan:      make(chan *schema.TlogBlock, maxTlbInBuffer),


### PR DESCRIPTION
Fixes #183:
- use redis pipelining to write data and update last_hash
- update tlog decoder to check&validate last hash from ALL storages.
- remove Metadata from tlog.RedisPool