### PR TITLE
Remove `chanSize` param from tlogclient.Recv API.

### DIFF
--- a/nbdserver/ardb/backend.go
+++ b/nbdserver/ardb/backend.go
@@ -237,7 +237,7 @@ func (ab *Backend) GoBackground(ctx context.Context) {
 		return
 	}
 
-	respChan := ab.tlogClient.Recv(transactionChCapacity)
+	respChan := ab.tlogClient.Recv()
 
 	log.Debug(
 		"starting backend background thread for vdisk:",

--- a/tlog/tlogclient/examples/send_tlog/client.go
+++ b/tlog/tlogclient/examples/send_tlog/client.go
@@ -55,7 +55,7 @@ func main() {
 	go func() {
 		defer wg.Done()
 
-		respChan := client.Recv(100)
+		respChan := client.Recv()
 		for {
 			r := <-respChan
 			if r.Err != nil {

--- a/tlog/tlogclient/reconnect_test.go
+++ b/tlog/tlogclient/reconnect_test.go
@@ -60,7 +60,7 @@ func waitForBlockReceivedResponse(t *testing.T, client *Client, minSequence, max
 		logsToRecv[i] = struct{}{}
 	}
 
-	respChan := client.Recv(1)
+	respChan := client.Recv()
 
 	for len(logsToRecv) > 0 {
 		// recv

--- a/tlog/tlogserver/server/server_test.go
+++ b/tlog/tlogserver/server/server_test.go
@@ -86,7 +86,7 @@ func TestEndToEnd(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		expected := numLogs + numFlush
-		respChan := client.Recv(1)
+		respChan := client.Recv()
 		for i := 0; i < expected; i++ {
 			re := <-respChan
 			if !assert.Nil(t, re.Err) {
@@ -235,7 +235,7 @@ func TestUnordered(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		respChan := client.Recv(1)
+		respChan := client.Recv()
 		for received < expected {
 			select {
 			case re := <-respChan:


### PR DESCRIPTION
Not usefull to make it configurable.